### PR TITLE
Parse manifest.json automatically when uploading CRX file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,24 @@ After packaging a CRX file, you can upload it to Brave's S3 extensions bucket (`
 To upload a component extension, use the appropriate upload command. For example, to upload all of the Ad Block component extensions use the following command:
 
 ```bash
-yarn run upload-ad-block --crx-directory <dir> --set-version <ver>
+yarn run upload-ad-block --crx-directory <dir>
 ```
 
 where:
 
 * `dir` is the directory containing the CRX files to upload (as produced by running `package-ad-block`, for example)
-* `ver` is the version number that identifies this extension
 
 ### Theme Extensions
 
 To upload all packaged theme extensions, use the following command:
 
 ```bash
-yarn run upload-themes --crx-directory <dir> --set-version <ver>
+yarn run upload-themes --crx-directory <dir>
 ```
 
 where:
 
 * `dir` is the directory containing the CRX files to upload
-* `ver` is the version number that identifies the extensions
 
 ## S3 Credentials
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -7,8 +7,9 @@ const crypto = require('crypto')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
+const unzip = require('unzip-crx')
 
-function createManifestForUpload (id, version, hash, name, outputDir) {
+const createManifestForUpload = (id, version, hash, name, outputDir) => {
   const manifestDir = path.join(outputDir, 'stable', 'extensions')
   const manifestFile = path.join(manifestDir, 'extensionManifest.json')
 
@@ -27,7 +28,7 @@ function createManifestForUpload (id, version, hash, name, outputDir) {
   fs.writeFileSync(manifestFile, JSON.stringify(content, null, 2))
 }
 
-function generateCRXFile (crxFile, privateKeyFile, inputDir, outputDir) {
+const generateCRXFile = (crxFile, privateKeyFile, inputDir, outputDir) => {
   const ChromeExtension = require('crx')
   const crx = new ChromeExtension({
     privateKey: fs.readFileSync(privateKeyFile)
@@ -47,16 +48,16 @@ function generateCRXFile (crxFile, privateKeyFile, inputDir, outputDir) {
     })
 }
 
-function generateSHA256Hash (data) {
+const generateSHA256Hash = (data) => {
   const hash = crypto.createHash('sha256')
   return hash.update(data).digest('hex')
 }
 
-function generateSHA256HashOfFile (file) {
+const generateSHA256HashOfFile = (file) => {
   return generateSHA256Hash(fs.readFileSync(file))
 }
 
-function getIDFromBase64PublicKey (key) {
+const getIDFromBase64PublicKey = (key) => {
   const hash = crypto.createHash('sha256')
   const data = Buffer.from(key, 'base64')
   const digest = hash.update(data).digest('hex')
@@ -66,7 +67,7 @@ function getIDFromBase64PublicKey (key) {
   })
 }
 
-function installErrorHandlers () {
+const installErrorHandlers = () => {
   process.on('uncaughtException', (err) => {
     console.error('Caught exception:', err)
     process.exit(1)
@@ -78,7 +79,36 @@ function installErrorHandlers () {
   })
 }
 
-function uploadExtension (id, version, hash, name, crxFile, outputDir) {
+const parseManifest = (manifestFile) => {
+  // Strip comments from manifest.json before parsing
+  const json = fs.readFileSync(manifestFile).toString('utf-8').replace(/\/\/#.*/g, '')
+  return JSON.parse(json)
+}
+
+const uploadCRXFile = (crxFile, outputDir) => {
+  const unzipDir = path.join('build', 'unzip', path.parse(crxFile).name)
+
+  mkdirp.sync(unzipDir)
+
+  unzip(crxFile, unzipDir).then(() => {
+    const manifest = path.join(unzipDir, 'manifest.json')
+    const data = parseManifest(manifest)
+
+    const id = getIDFromBase64PublicKey(data.key)
+    const version = data.version
+    const hash = generateSHA256HashOfFile(crxFile)
+    const name = data.name
+
+    const result = uploadExtension(id, version, hash, name, crxFile, outputDir)
+    if (result) {
+      console.log(result)
+    }
+
+    console.log(`Uploaded ${crxFile}`)
+  })
+}
+
+const uploadExtension = (id, version, hash, name, crxFile, outputDir) => {
   const script = path.join('node_modules', 'release-tools', 'bin', 'updateExtensions')
 
   let args = ''
@@ -101,5 +131,6 @@ module.exports = {
   generateSHA256HashOfFile,
   getIDFromBase64PublicKey,
   installErrorHandlers,
+  uploadCRXFile,
   uploadExtension
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,19 +37,12 @@
       }
     },
     "ad-block": {
-      "version": "github:brave/ad-block#84d11620a91e653309a80f1e223a7644a1ca9c36",
+      "version": "github:brave/ad-block#9e4aeed5992b438b89b898d74d4898a44f97301c",
       "requires": {
-        "bloom-filter-cpp": "1.1.8",
+        "bloom-filter-cpp": "1.2.0",
         "cppunitlite": "1.0.0",
-        "hashset-cpp": "2.0.1",
+        "hashset-cpp": "2.1.0",
         "nan": "2.10.0"
-      },
-      "dependencies": {
-        "hashset-cpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.0.1.tgz",
-          "integrity": "sha512-V8UG1tyTwM+vglF+WaboKkvtBrZhNbHMKe/XJLaPLz0JRs5S5qTxU636qHTC91lJMi7zCNEFi0u491dUtzVjgA=="
-        }
       }
     },
     "ajv": {
@@ -328,9 +321,9 @@
       }
     },
     "bloom-filter-cpp": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/bloom-filter-cpp/-/bloom-filter-cpp-1.1.8.tgz",
-      "integrity": "sha512-2Kpu+n7erlVbw/SOD5HxLIzXALMBy/RivAI0GBfx9Hp3WbIYrGBg3lKW9iPIY6WQGDCuLUHbjlU93WDpVg8Ehg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bloom-filter-cpp/-/bloom-filter-cpp-1.2.0.tgz",
+      "integrity": "sha512-R5axBRU0tvJK6tZmTFj8pMdjWtjh6eUWDUVj2I8nyeCYVOUKbW+uzM8VsWvMlAYs82fdUUZmA4/rNGkHW+dPNw=="
     },
     "boom": {
       "version": "4.3.1",
@@ -1452,9 +1445,9 @@
       "dev": true
     },
     "hashset-cpp": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-1.0.18.tgz",
-      "integrity": "sha512-CBMnVXVpNbTZyuq19lJwQTxJ3y9X2iBcBcVw7SHdHw/G4HW8Rwj+x0henrnjsTu7oWhSOnRIh0NfVGMj1yJ+fg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.1.0.tgz",
+      "integrity": "sha512-+HbrTNQH/qiWeObpS0ZFP0INA4yalHCm0j/lHW1V6h106DO+EOp26xQQqFsjGtrqy6vgB7hucTZarByazSd1Uw=="
     },
     "hawk": {
       "version": "6.0.2",
@@ -1508,6 +1501,12 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
       "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "imurmurhash": {
@@ -1770,6 +1769,59 @@
         "array-includes": "3.0.3"
       }
     },
+    "jszip": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+          "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+          "dev": true
+        },
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -1911,6 +1963,15 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true,
+      "requires": {
+        "immediate": "3.0.6"
       }
     },
     "load-json-file": {
@@ -2237,6 +2298,12 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+      "dev": true
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -2561,7 +2628,7 @@
       }
     },
     "release-tools": {
-      "version": "github:brave/release-tools#e0a2f175f3e76f30fed8161eeb1e0cb4596fd1f8",
+      "version": "github:brave/release-tools#74523c674dcc6da6a0997e830709022387f2efb7",
       "requires": {
         "async": "2.6.0",
         "aws-sdk": "2.252.1",
@@ -3245,10 +3312,10 @@
       }
     },
     "tracking-protection": {
-      "version": "github:brave/tracking-protection#051177425a14121a22087d754ad8eb1c0ce8fb24",
+      "version": "github:brave/tracking-protection#269dd88b53513c13f8e3c25e69b63e932553b831",
       "requires": {
         "cppunitlite": "1.0.0",
-        "hashset-cpp": "1.0.18",
+        "hashset-cpp": "2.1.0",
         "mkdirp": "0.5.1",
         "nan": "2.10.0"
       }
@@ -3304,6 +3371,17 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
+    },
+    "unzip-crx": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/unzip-crx/-/unzip-crx-0.2.0.tgz",
+      "integrity": "sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=",
+      "dev": true,
+      "requires": {
+        "jszip": "3.1.5",
+        "mkdirp": "0.5.1",
+        "yaku": "0.16.7"
+      }
     },
     "url": {
       "version": "0.10.3",
@@ -3490,6 +3568,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yaku": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/yaku/-/yaku-0.16.7.tgz",
+      "integrity": "sha1-HRlceKqbW/hHnIlblQT9TwhHmE4=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mkdirp": "^0.5.1",
     "replace-in-file": "^3.4.0",
     "rimraf": "^2.6.2",
-    "standard": "^11.0.1"
+    "standard": "^11.0.1",
+    "unzip-crx": "^0.2.0"
   },
   "scripts": {
     "clean": "rimraf build/",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -9,7 +9,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const replace = require('replace-in-file')
 
-const {generateCRXFile, installErrorHandlers} = require('./lib/util')
+const {generateCRXFile, installErrorHandlers} = require('../lib/util')
 
 const stageFiles = (componentType, datFile, outputDir) => {
   const parsedDatFile = path.parse(datFile)

--- a/scripts/packageThemes.js
+++ b/scripts/packageThemes.js
@@ -9,9 +9,9 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const replace = require('replace-in-file')
 
-const {generateCRXFile, installErrorHandlers} = require('./lib/util')
+const {generateCRXFile, installErrorHandlers} = require('../lib/util')
 
-function stageTheme (themeDir, themeName, outputDir) {
+const stageTheme = (themeDir, themeName, outputDir) => {
   const originalManifest = path.join(themeDir, 'manifest.json')
   const outputManifest = path.join(outputDir, themeName, 'manifest.json')
 
@@ -40,7 +40,7 @@ function stageTheme (themeDir, themeName, outputDir) {
   fsx.copySync(originalImagesDir, outputImagesDir)
 }
 
-function generateCRXFiles (outputDir) {
+const generateCRXFiles = (outputDir) => {
   const themesDir = path.join('node_modules', 'brave-chromium-themes')
   fs.readdirSync(themesDir).forEach(file => {
     if (fs.lstatSync(path.join(themesDir, file)).isDirectory()) {

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -10,7 +10,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const replace = require('replace-in-file')
 
-const {generateCRXFile, installErrorHandlers} = require('./lib/util')
+const {generateCRXFile, installErrorHandlers} = require('../lib/util')
 
 // Downloads the current (platform-specific) Tor client from S3
 const downloadTorClient = (platform) => {

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -5,38 +5,13 @@
 const commander = require('commander')
 const fs = require('fs')
 const path = require('path')
-const util = require('./lib/util.js')
-
-function parseManifest (manifestFile) {
-  return JSON.parse(fs.readFileSync(manifestFile))
-}
-
-function uploadCRXFile (crxFile) {
-  const outputDir = path.join('build', commander.type)
-
-  const crxFileName = path.parse(crxFile).name
-  const manifest = path.join('manifests', `${crxFileName}-manifest.json`)
-  const data = parseManifest(manifest)
-
-  const id = util.getIDFromBase64PublicKey(data.key)
-  const version = commander.setVersion
-  const hash = util.generateSHA256HashOfFile(crxFile)
-  const name = data.name
-
-  const result = util.uploadExtension(id, version, hash, name, crxFile, outputDir)
-  if (result) {
-    console.log(result)
-  }
-
-  console.log(`Uploaded ${crxFile}`)
-}
+const util = require('../lib/util')
 
 util.installErrorHandlers()
 
 commander
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
-  .option('-s, --set-version <x.x.x>', 'component extension version number')
   .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|tracking-protection-updater)$/i, 'ad-block-updater')
   .parse(process.argv)
 
@@ -50,16 +25,13 @@ if (fs.existsSync(commander.crxFile)) {
   throw new Error('Missing or invalid crx file/directory')
 }
 
-if (!commander.setVersion || !commander.setVersion.match(/^(\d+\.\d+\.\d+)$/)) {
-  throw new Error('Missing or invalid option: --set-version')
-}
-
+const outputDir = path.join('build', commander.type)
 if (fs.lstatSync(crxParam).isDirectory()) {
   fs.readdirSync(crxParam).forEach(file => {
     if (path.parse(file).ext === '.crx') {
-      uploadCRXFile(path.join(crxParam, file))
+      util.uploadCRXFile(path.join(crxParam, file), outputDir)
     }
   })
 } else {
-  uploadCRXFile(crxParam)
+  util.uploadCRXFile(crxParam, outputDir)
 }

--- a/scripts/uploadThemes.js
+++ b/scripts/uploadThemes.js
@@ -5,52 +5,21 @@
 const commander = require('commander')
 const fs = require('fs')
 const path = require('path')
-const util = require('./lib/util.js')
-
-function parseManifest (manifestFile) {
-  // Strip comments from manifest.json before parsing
-  const json = fs.readFileSync(manifestFile).toString('utf-8').replace(/\/\/#.*/g, '')
-  return JSON.parse(json)
-}
-
-function uploadCRXFile (crxFile) {
-  const outputDir = path.join('build', 'themes')
-  const themeName = path.parse(crxFile).name
-
-  const manifest = path.join('node_modules', 'brave-chromium-themes', themeName, 'manifest.json')
-  const data = parseManifest(manifest)
-
-  const id = util.getIDFromBase64PublicKey(data.key)
-  const version = commander.setVersion
-  const hash = util.generateSHA256HashOfFile(crxFile)
-  const name = data.name
-
-  const result = util.uploadExtension(id, version, hash, name, crxFile, outputDir)
-  if (result) {
-    console.log(result)
-  }
-
-  console.log(`Uploaded ${crxFile}`)
-}
+const util = require('../lib/util')
 
 util.installErrorHandlers()
 
 commander
   .option('-c, --crx-directory <dir>', 'crx directory')
-  .option('-s, --set-version <x.x.x>', 'extension version number')
   .parse(process.argv)
 
 if (!commander.crxDirectory || !fs.lstatSync(commander.crxDirectory).isDirectory()) {
   throw new Error('Missing or invalid option: --crx-directory')
 }
 
-if (!commander.setVersion || !commander.setVersion.match(/^(\d+\.\d+\.\d+)$/)) {
-  throw new Error('Missing or invalid option: --set-version')
-}
-
 const outputDir = path.join('build', 'themes')
 fs.readdirSync(commander.crxDirectory).forEach(file => {
   if (path.extname(file) === '.crx') {
-    uploadCRXFile(path.join(outputDir, file))
+    util.uploadCRXFile(path.join(outputDir, file), outputDir)
   }
 })

--- a/scripts/uploadTorClient.js
+++ b/scripts/uploadTorClient.js
@@ -5,38 +5,13 @@
 const commander = require('commander')
 const fs = require('fs')
 const path = require('path')
-const util = require('./lib/util.js')
-
-const parseManifest = (manifestFile) => {
-  return JSON.parse(fs.readFileSync(manifestFile))
-}
-
-const uploadCRXFile = (crxFile) => {
-  const outputDir = path.join('build', 'tor-client-updater')
-
-  const crxFileName = path.parse(crxFile).name
-  const manifest = path.join('manifests', 'tor-client-updater', `${crxFileName}-manifest.json`)
-  const data = parseManifest(manifest)
-
-  const id = util.getIDFromBase64PublicKey(data.key)
-  const version = commander.setVersion
-  const hash = util.generateSHA256HashOfFile(crxFile)
-  const name = data.name
-
-  const result = util.uploadExtension(id, version, hash, name, crxFile, outputDir)
-  if (result) {
-    console.log(result)
-  }
-
-  console.log(`Uploaded ${crxFile}`)
-}
+const util = require('../lib/util')
 
 util.installErrorHandlers()
 
 commander
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
-  .option('-s, --set-version <x.x.x>', 'component extension version number')
   .parse(process.argv)
 
 let crxParam = ''
@@ -49,16 +24,13 @@ if (fs.existsSync(commander.crxFile)) {
   throw new Error('Missing or invalid crx file/directory')
 }
 
-if (!commander.setVersion || !commander.setVersion.match(/^(\d+\.\d+\.\d+)$/)) {
-  throw new Error('Missing or invalid option: --set-version')
-}
-
+const outputDir = path.join('build', 'tor-client-updater')
 if (fs.lstatSync(crxParam).isDirectory()) {
   fs.readdirSync(crxParam).forEach(file => {
     if (path.parse(file).ext === '.crx') {
-      uploadCRXFile(path.join(crxParam, file))
+      util.uploadCRXFile(path.join(crxParam, file), outputDir)
     }
   })
 } else {
-  uploadCRXFile(crxParam)
+  util.uploadCRXFile(crxParam, outputDir)
 }


### PR DESCRIPTION
Fixes #8 

Refactors scripts to upload CRX files without requiring user to specify the version number on the command line.