### PR TITLE
Update to the latest version of release-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -633,6 +633,11 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
       "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
     },
+    "crypto-browserify": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2029,11 +2034,6 @@
         "mimic-fn": "1.2.0"
       }
     },
-    "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -2096,11 +2096,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-    },
-    "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2628,14 +2623,14 @@
       }
     },
     "release-tools": {
-      "version": "github:brave/release-tools#74523c674dcc6da6a0997e830709022387f2efb7",
+      "version": "github:brave/release-tools#157a84f84ae3438a5a348261655b05fe65af4eb2",
       "requires": {
         "async": "2.6.0",
         "aws-sdk": "2.252.1",
         "crypto": "0.0.3",
         "glob": "7.1.2",
         "request": "2.85.0",
-        "s3": "4.4.0",
+        "s3-node-client": "4.4.4",
         "semver": "5.5.0",
         "underscore": "1.9.1",
         "xmldoc": "1.1.0",
@@ -2927,16 +2922,16 @@
         "rx-lite": "4.0.8"
       }
     },
-    "s3": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/s3/-/s3-4.4.0.tgz",
-      "integrity": "sha1-VqT3dVFae2ucjlxrGrUfkDdmnx8=",
+    "s3-node-client": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/s3-node-client/-/s3-node-client-4.4.4.tgz",
+      "integrity": "sha1-cF8c6ip9IzB3M1LGSQCEdft2e2w=",
       "requires": {
-        "aws-sdk": "2.0.31",
+        "aws-sdk": "2.67.0",
         "fd-slicer": "1.0.1",
         "findit2": "2.2.3",
-        "graceful-fs": "3.0.11",
-        "mime": "1.2.11",
+        "graceful-fs": "4.1.11",
+        "mime": "2.3.1",
         "mkdirp": "0.5.1",
         "pend": "1.2.0",
         "rimraf": "2.2.8",
@@ -2944,44 +2939,44 @@
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.0.31",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
-          "integrity": "sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=",
+          "version": "2.67.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.67.0.tgz",
+          "integrity": "sha1-wPw6Q0PPxjEmXZ3WvFC6cJQB+Fc=",
           "requires": {
-            "xml2js": "0.2.6",
-            "xmlbuilder": "0.4.2"
+            "buffer": "5.0.6",
+            "crypto-browserify": "1.0.9",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.0.1",
+            "xml2js": "0.4.17",
+            "xmlbuilder": "4.2.1"
           }
         },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+        "buffer": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+          "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
           "requires": {
-            "natives": "1.1.4"
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.8"
           }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
         },
         "rimraf": {
           "version": "2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         },
-        "sax": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
-          "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw="
-        },
-        "xml2js": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
-          "integrity": "sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=",
-          "requires": {
-            "sax": "0.4.2"
-          }
-        },
-        "xmlbuilder": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
-          "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M="
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
         }
       }
     },


### PR DESCRIPTION
The latest version of `release-tools` was updated to use `s3-node-client`, a dependency update fork of an older node package. The old package relied on a version of `mime` < `1.4.1`, which had an identified security vulnerability.