### PR TITLE
added ipfs to crx packaging files

### DIFF
--- a/manifests/ipfs-daemon-updater/ipfs-daemon-updater-darwin-manifest.json
+++ b/manifests/ipfs-daemon-updater/ipfs-daemon-updater-darwin-manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave Ipfs Client Updater extension",
+  // "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw2QUXSbVuRxYpItYApZ8Ly/fGeUD3A+vb3J7Ot62CF32wTfWweANWyyB+EBGfbtNDAuRlAbNk0QYeCQEttufjLh3Kd5KR5fSyyNNd2cAzAckQ8p7JdiFYjvqZLGC5vlnHgqq4O8xACX5EPwHLNFDiSpsthNmz3GCUrHrzPHjHVfy+IuucQXygnRv2fwIaAIxJmTbYm4fqsGKpfolWdMejKVAy1hc9mApZSyt4oGvUu4SJZnxlYMrY4Ze+OWbDesi2JGy+6dA1ddL9IdnwCb39CBOMNjaHeCVz0MKxdCWGPieQM0R7S1KvDCVqAkss6NAbLB6AVM0JulqxC9b+hr/xwIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave Ipfs Client Updater (Mac)",
+  "version": "0.0.0"
+}

--- a/manifests/ipfs-daemon-updater/ipfs-daemon-updater-linux-manifest.json
+++ b/manifests/ipfs-daemon-updater/ipfs-daemon-updater-linux-manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave Ipfs Client Updater extension",
+  // "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAseuq8dXKawkZC7RSE7xblRwh6DD+oPEGEjZWKh596/42IrWNQw60gRIR6s7x0YHh5geFnBRkx9bisEXOrFkqoArVY7eD0gMkjpor9CneD5CnCxc9/2uIPajtXfAmmLAHtN6Wk7yW30SkRf/WvLWX/H+PqskQBN7I5MO7sveYxSrRMSj7prrFHEiFmXTgG/DwjpzrA7KV6vmzz/ReD51o+UuLHE7cxPhnsNd/52uY3Lod3GhxvDoXKYx9kWlzBjxB53A2eLBCDIwwCpqS4/IbRSJhvF33KQT8YM+7V1MitwB49klP4aEWPXwOlFHmn9Dkmlx2RbO7S0tRcH9UH4LK2QIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave Ipfs Client Updater (Linux)",
+  "version": "0.0.0"
+}

--- a/manifests/ipfs-daemon-updater/ipfs-daemon-updater-win32-manifest.json
+++ b/manifests/ipfs-daemon-updater/ipfs-daemon-updater-win32-manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave Ipfs Client Updater extension",
+  // "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1AYAsmR/VoRwkZCsjRpD58xjrgngW5y17H6BqQ7/CeNSpmXlcMXy6bJs2D/yeS96rhZSrQSHTzS9h/ieo/NZF5PIwcv07YsG5sRd6zF5a6m92aWCQa1OkbL6jpcpL2Tbc4mCqNxhKMErT7EtIIWL9cW+mtFUjUjvV3rJLQ3Vy9u6fEi77Y8b25kGnTJoVt3uETAIHBnyNpL7ac2f8Iq+4Qa6VFmuoBhup54tTZvMv+ikoKKaQkHzkkjTa4hV5AzdnFDKO8C9qJb3T/Ef0+MOIuZjyySVzGNcOfASeHkhxhlwMQSQuhCN5mdFW5YBnVZ/5QWx8WzbhqBny/ZynS4erQIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave Ipfs Client Updater (Windows)",
+  "version": "0.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "package-https-everywhere": "node ./scripts/packageComponent --type https-everywhere-updater",
     "package-themes": "node ./scripts/packageThemes",
     "package-tor-client": "node ./scripts/packageTorClient",
+    "package-ipfs-daemon": "node ./scripts/packageIpfsDaemon",
     "package-tracking-protection": "node ./scripts/packageComponent --type tracking-protection-updater",
     "upload-ad-block": "node ./scripts/uploadComponent --type ad-block-updater",
     "upload-https-everywhere": "node ./scripts/uploadComponent --type https-everywhere-updater",

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+// npm run package-ipfs-daemon -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir --set-version 1.0.1
+
+const commander = require('commander')
+const crypto = require('crypto')
+const execSync = require('child_process').execSync
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const path = require('path')
+const replace = require('replace-in-file')
+
+const {generateCRXFile, installErrorHandlers} = require('../lib/util')
+
+// Downloads the current (platform-specific) Ipfs Daemon from S3
+const downloadIpfsDaemon = (platform) => {
+  const ipfsPath = path.join('build', 'ipfs-daemon-updater', 'downloads')
+
+  const ipfsDistPrefix = 'https://ipfs.io/ipns/dist.ipfs.io/go-ipfs/v0.4.17/'
+
+  const ipfsVersion = '0.4.17'
+  const braveVersion = '5'
+  const exeSuffix = platform === 'win32' ? '.zip' : '.tar.gz'
+  const myplatform = platform === 'win32' ? 'windows' : platform
+
+  const ipfsFilename = `go-ipfs_v${ipfsVersion}_${myplatform}-amd64`
+  const ipfsURL = ipfsDistPrefix + ipfsFilename + exeSuffix
+
+  let sha512IPFS = ''
+
+  switch (platform) {
+    case 'darwin':
+    sha512IPFS = 'c3d18404f257fcf8674ca0afcd45bf36501624c10a8642d59d52deb850383b7f136f4849919a1a4560eee1af61705cd91dd01b3e219fb38d0582cace2b0b03d7'
+      break
+    case 'linux':
+    sha512IPFS = 'e4131388efe52d0ec0e68fa3c0110c43fc58e2a5c5bb2c72062f5b947c7622dff78cde1181029331144298f15879887c20173d0eada368e7051f4f2b5c6b41ef'
+      break
+    case 'win32':
+    sha512IPFS = 'b9175c6f1b624ee1e5db3076f5f5859c4e5dd9abc050f75c6a4ee5ecb7ab89b8fdec965c88b851775b369bc08a8c2dfc0d84807726a4f24448eacfc0e48cdc6c'
+      break
+    default:
+      throw new Error('Ipfs Daemon download failed; unrecognized platform: ' + platform)
+  }
+
+  mkdirp.sync(ipfsPath)
+  const ipfsDaemon = path.join(ipfsPath, ipfsFilename)
+  // Build decompression command based on system
+  const decompressUnix = ' | tar xf - -C  ' + ipfsPath + ' && cp ' + ipfsPath + '/go-ipfs/ipfs ' + ipfsDaemon 
+  const decompressWindows = ' | bsdtar -xf- -C ' + ipfsPath + ' && cp ' + ipfsPath + '/go-ipfs/ipfs.exe ' + ipfsDaemon 
+  const decompress = platform === 'win32' ? decompressWindows : decompressUnix
+  const cmd = 'curl -s ' + ipfsURL + decompress
+
+  // Download and decompress the client
+  execSync(cmd)
+
+  // Verify the checksum
+  if (!verifyChecksum(ipfsDaemon, sha512IPFS)) {
+    console.error('Ipfs Daemon checksum verification failed')
+    process.exit(1)
+  }
+
+  // Make it executable
+  fs.chmodSync(ipfsDaemon, 0o755)
+
+  return ipfsDaemon
+}
+
+const packageIpfsDaemon = (binary, platform, key) => {
+  const stagingDir = path.join('build', 'ipfs-daemon-updater', platform)
+  const ipfsDaemon = downloadIpfsDaemon(platform)
+  const crxOutputDir = path.join('build', 'ipfs-daemon-updater')
+  const crxFile = path.join(crxOutputDir, `ipfs-daemon-updater-${platform}.crx`)
+  const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `ipfs-daemon-updater-${platform}.pem`)
+  stageFiles(platform, ipfsDaemon, stagingDir)
+  generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+}
+
+const stageFiles = (platform, ipfsDaemon, outputDir) => {
+  const originalManifest = path.join('manifests', 'ipfs-daemon-updater', `ipfs-daemon-updater-${platform}-manifest.json`)
+  const outputManifest = path.join(outputDir, 'manifest.json')
+  const outputTorClient = path.join(outputDir, path.parse(ipfsDaemon).base)
+
+  const replaceOptions = {
+    files: outputManifest,
+    from: /0\.0\.0/,
+    to: commander.setVersion
+  }
+
+  mkdirp.sync(outputDir)
+
+  fs.copyFileSync(originalManifest, outputManifest)
+  fs.copyFileSync(ipfsDaemon, outputTorClient)
+
+  replace.sync(replaceOptions)
+}
+
+// Does a hash comparison on a file against a given hash
+const verifyChecksum = (file, hash) => {
+  const filecontent = fs.readFileSync(file)
+  return hash === crypto.createHash('sha512').update(filecontent).digest('hex')
+}
+
+installErrorHandlers()
+
+commander
+  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
+  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
+  .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
+  .option('-s, --set-version <x.x.x>', 'component extension version number')
+  .parse(process.argv)
+
+let keyParam = ''
+
+if (fs.existsSync(commander.keyFile)) {
+  keyParam = commander.keyFile
+} else if (fs.existsSync(commander.keysDirectory)) {
+  keyParam = commander.keysDirectory
+} else {
+  throw new Error('Missing or invalid private key file/directory')
+}
+
+if (!commander.setVersion || !commander.setVersion.match(/^(\d+\.\d+\.\d+)$/)) {
+  throw new Error('Missing or invalid option: --set-version')
+}
+
+if (!commander.binary) {
+  throw new Error('Missing Chromium binary: --binary')
+}
+
+packageIpfsDaemon(commander.binary, 'darwin', keyParam)
+packageIpfsDaemon(commander.binary, 'linux', keyParam)
+packageIpfsDaemon(commander.binary, 'win32', keyParam)

--- a/scripts/uploadIpfsDaemon.js
+++ b/scripts/uploadIpfsDaemon.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const commander = require('commander')
+const fs = require('fs')
+const path = require('path')
+const util = require('../lib/util')
+
+util.installErrorHandlers()
+
+commander
+  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data/')
+  .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
+  .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
+  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
+  .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
+  .parse(process.argv)
+
+let crxParam = ''
+
+if (fs.existsSync(commander.crxFile)) {
+  crxParam = commander.crxFile
+} else if (fs.existsSync(commander.crxDirectory)) {
+  crxParam = commander.crxDirectory
+} else {
+  throw new Error('Missing or invalid crx file/directory')
+}
+
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  const outputDir = path.join('build', 'ipfs-daemon-updater')
+  if (fs.lstatSync(crxParam).isDirectory()) {
+    fs.readdirSync(crxParam).forEach(file => {
+      if (path.parse(file).ext === '.crx') {
+        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file), outputDir)
+      }
+    })
+  } else {
+    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam, outputDir)
+  }
+})


### PR DESCRIPTION
Adding files to package go-ipfs as a brave-core-crx, similar to the Tor crx implementation

What is needed to manage the IPFS binary from the brave-core C++ side? 

I see a PR here that seems to have those controls for Tor [https://github.com/brave/brave-core/commit/ed7c0abca2f29526743ea05646056254af5f397f](https://github.com/brave/brave-core/commit/ed7c0abca2f29526743ea05646056254af5f397f)

@lidel @emerick @bsclifton @darkdh 