### PR TITLE
Auto increment extension versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ yarn run data-files-ad-block
 Then package the component extension(s) into one or more CRX files. For example, to package all of the Ad Block component extensions use the following command:
 
 ```bash
-yarn run package-ad-block --keys-directory <dir> --set-version <ver>
+yarn run package-ad-block --keys-directory <keys-dir> --binary <binary> --endpoint <endpoint>
 ```
 
 where:
 
-* `dir` is the directory containing the associated private keys used to sign the CRX files
-* `ver` is the version number that identifies this extension
+* `keys-dir` is the directory containing the associated private keys used to sign the CRX files
+* `binary` is the full path to the Chrome web browser binary, used for packing the CRX files
+* `endpoint` is the DynamoDB endpoint (use http://localhost:8000 if setup locally)
 
 The currently supported component extension types are:
 
@@ -45,13 +46,14 @@ The currently supported component extension types are:
 To package all available theme extensions into CRX files, use the following command:
 
 ```bash
-yarn run package-themes --keys-directory <dir> --set-version <ver>
+yarn run package-themes --keys-directory <keys-dir> --binary <binary> --endpoint <endpoint>
 ```
 
 where:
 
-* `dir` is the directory containing the associated private keys used to sign the CRX files
-* `ver` is the version number that identifies the extensions
+* `keys-dir` is the directory containing the associated private keys used to sign the CRX files
+* `binary` is the full path to the Chrome web browser binary, used for packing the CRX files
+* `endpoint` is the DynamoDB endpoint (use http://localhost:8000 if setup locally)
 
 ## Uploading
 
@@ -62,24 +64,30 @@ After packaging a CRX file, you can upload it to Brave's S3 extensions bucket (`
 To upload a component extension, use the appropriate upload command. For example, to upload all of the Ad Block component extensions use the following command:
 
 ```bash
-yarn run upload-ad-block --crx-directory <dir>
+yarn run upload-ad-block --crx-directory <crx-dir> --vault-updater-path <vu-dir>
 ```
 
 where:
 
-* `dir` is the directory containing the CRX files to upload (as produced by running `package-ad-block`, for example)
+* `crx-dir` is the directory containing the CRX files to upload (as produced by running `package-ad-block`, for example)
+* `vu-dir` is the full path to the local vault-updater
 
 ### Theme Extensions
 
 To upload all packaged theme extensions, use the following command:
 
 ```bash
-yarn run upload-themes --crx-directory <dir>
+yarn run upload-themes --crx-directory <dir> --vault-updater-path <vu-dir>
 ```
 
 where:
 
 * `dir` is the directory containing the CRX files to upload
+* `vu-dir` is the full path to the local vault-updater
+
+## Versioning
+
+Versioning occurs automatically. The first time an extension is packaged, it receives the version number `1.0.0`. When uploaded, that version number along with other metadata is stored in DynamoDB. Subsequent packagings increment the last component of the version number by one.
 
 ## S3 Credentials
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,6 +38,12 @@ const getIDFromBase64PublicKey = (key) => {
   })
 }
 
+const incrementVersion = (version) => {
+  const versionParts = version.split('.')
+  versionParts[versionParts.length - 1]++
+  return versionParts.join('.')
+}
+
 const installErrorHandlers = () => {
   process.on('uncaughtException', (err) => {
     console.error('Caught exception:', err)
@@ -142,6 +148,26 @@ const createTableIfNotExists = (endpoint, region) => {
     })
 }
 
+const getNextVersion = (endpoint, region, id) => {
+  const dynamodb = createDynamoDBInstance(endpoint, region)
+  const params = {
+    ExpressionAttributeValues: {
+      ':id': {
+        S: id
+      }
+    },
+    KeyConditionExpression: 'ID = :id',
+    TableName: DynamoDBTableName
+  }
+  return dynamodb.query(params).promise().then((data) => {
+    if (data.Items.length === 1 && data.Items[0].Version.S !== '') {
+      return incrementVersion(data.Items[0].Version.S)
+    } else {
+      return '1.0.0'
+    }
+  })
+}
+
 const updateDynamoDB = (endpoint, region, id, version, hash, name, disabled) => {
   const dynamodb = createDynamoDBInstance(endpoint, region)
   const params = {
@@ -172,8 +198,10 @@ module.exports = {
   createTableIfNotExists,
   generateCRXFile,
   generateSHA256HashOfFile,
+  getNextVersion,
   getIDFromBase64PublicKey,
   installErrorHandlers,
+  parseManifest,
   uploadCRXFile,
   uploadExtension
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1454,7 +1454,7 @@
       }
     },
     "https-everywhere-builder": {
-      "version": "github:brave/https-everywhere-builder#272d8c4e2afe18acf6ff62410711fdaa9bff85f1"
+      "version": "github:brave/https-everywhere-builder#5ace2ca9ba8172e609260e35e0afe24e73c4f034"
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -2565,7 +2565,7 @@
       }
     },
     "release-tools": {
-      "version": "github:brave/release-tools#157a84f84ae3438a5a348261655b05fe65af4eb2",
+      "version": "github:brave/release-tools#a3a89d82b98db54e047ff27e518b063ab30aa1c6",
       "requires": {
         "async": "2.6.1",
         "aws-sdk": "2.304.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "package-tracking-protection": "node ./scripts/packageComponent --type tracking-protection-updater",
     "upload-ad-block": "node ./scripts/uploadComponent --type ad-block-updater",
     "upload-https-everywhere": "node ./scripts/uploadComponent --type https-everywhere-updater",
-    "upload-ipfs-daemon": "node ./scripts/uploadDaemon",
+    "upload-ipfs-daemon": "node ./scripts/uploadIpfsDaemon",
     "upload-themes": "node ./scripts/uploadThemes",
     "upload-tor-client": "node ./scripts/uploadTorClient",
     "upload-tracking-protection": "node ./scripts/uploadComponent --type tracking-protection-updater"

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Example usage:
-// npm run package-ipfs-daemon -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir --set-version 1.0.1
+// npm run package-ipfs-daemon -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir
 
 const commander = require('commander')
 const crypto = require('crypto')
@@ -12,8 +12,7 @@ const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const replace = require('replace-in-file')
-
-const {generateCRXFile, installErrorHandlers} = require('../lib/util')
+const util = require('../lib/util')
 
 // Downloads the current (platform-specific) Ipfs Daemon from S3
 const downloadIpfsDaemon = (platform) => {
@@ -67,25 +66,36 @@ const downloadIpfsDaemon = (platform) => {
   return ipfsDaemon
 }
 
-const packageIpfsDaemon = (binary, platform, key) => {
-  const stagingDir = path.join('build', 'ipfs-daemon-updater', platform)
-  const ipfsDaemon = downloadIpfsDaemon(platform)
-  const crxOutputDir = path.join('build', 'ipfs-daemon-updater')
-  const crxFile = path.join(crxOutputDir, `ipfs-daemon-updater-${platform}.crx`)
-  const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `ipfs-daemon-updater-${platform}.pem`)
-  stageFiles(platform, ipfsDaemon, stagingDir)
-  generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+const getOriginalManifest = (platform) => {
+  return path.join('manifests', 'ipfs-daemon-updater', `ipfs-daemon-updater-${platform}-manifest.json`)
 }
 
-const stageFiles = (platform, ipfsDaemon, outputDir) => {
-  const originalManifest = path.join('manifests', 'ipfs-daemon-updater', `ipfs-daemon-updater-${platform}-manifest.json`)
+const packageIpfsDaemon = (binary, endpoint, region, platform, key) => {
+  const originalManifest = getOriginalManifest(platform)
+  const parsedManifest = util.parseManifest(originalManifest)
+  const id = util.getIDFromBase64PublicKey(parsedManifest.key)
+
+  util.getNextVersion(endpoint, region, id).then((version) => {
+    const stagingDir = path.join('build', 'ipfs-daemon-updater', platform)
+    const ipfsDaemon = downloadIpfsDaemon(platform)
+    const crxOutputDir = path.join('build', 'ipfs-daemon-updater')
+    const crxFile = path.join(crxOutputDir, `ipfs-daemon-updater-${platform}.crx`)
+    const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `ipfs-daemon-updater-${platform}.pem`)
+    stageFiles(platform, ipfsDaemon, version, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
+  const originalManifest = getOriginalManifest(platform)
   const outputManifest = path.join(outputDir, 'manifest.json')
   const outputTorClient = path.join(outputDir, path.parse(ipfsDaemon).base)
 
   const replaceOptions = {
     files: outputManifest,
     from: /0\.0\.0/,
-    to: commander.setVersion
+    to: version
   }
 
   mkdirp.sync(outputDir)
@@ -102,13 +112,14 @@ const verifyChecksum = (file, hash) => {
   return hash === crypto.createHash('sha512').update(filecontent).digest('hex')
 }
 
-installErrorHandlers()
+util.installErrorHandlers()
 
 commander
   .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
   .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
   .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-  .option('-s, --set-version <x.x.x>', 'component extension version number')
+  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
+  .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
   .parse(process.argv)
 
 let keyParam = ''
@@ -121,14 +132,10 @@ if (fs.existsSync(commander.keyFile)) {
   throw new Error('Missing or invalid private key file/directory')
 }
 
-if (!commander.setVersion || !commander.setVersion.match(/^(\d+\.\d+\.\d+)$/)) {
-  throw new Error('Missing or invalid option: --set-version')
-}
-
 if (!commander.binary) {
   throw new Error('Missing Chromium binary: --binary')
 }
 
-packageIpfsDaemon(commander.binary, 'darwin', keyParam)
-packageIpfsDaemon(commander.binary, 'linux', keyParam)
-packageIpfsDaemon(commander.binary, 'win32', keyParam)
+packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
+packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
+packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -29,14 +29,13 @@ if (fs.existsSync(commander.crxFile)) {
 }
 
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  const outputDir = path.join('build', commander.type)
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file), outputDir)
+        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam, outputDir)
+    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
   }
 })

--- a/scripts/uploadIpfsDaemon.js
+++ b/scripts/uploadIpfsDaemon.js
@@ -28,14 +28,13 @@ if (fs.existsSync(commander.crxFile)) {
 }
 
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  const outputDir = path.join('build', 'ipfs-daemon-updater')
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file), outputDir)
+        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam, outputDir)
+    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
   }
 })

--- a/scripts/uploadThemes.js
+++ b/scripts/uploadThemes.js
@@ -24,7 +24,7 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const outputDir = path.join('build', 'themes')
   fs.readdirSync(commander.crxDirectory).forEach(file => {
     if (path.extname(file) === '.crx') {
-      util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(outputDir, file), outputDir)
+      util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(outputDir, file))
     }
   })
 })

--- a/scripts/uploadTorClient.js
+++ b/scripts/uploadTorClient.js
@@ -28,14 +28,13 @@ if (fs.existsSync(commander.crxFile)) {
 }
 
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  const outputDir = path.join('build', 'tor-client-updater')
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file), outputDir)
+        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam, outputDir)
+    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
   }
 })


### PR DESCRIPTION
Fixes #20

### Test Plan

Package an extension and note version number used (output to console):

```
npm run package-ad-block -- --keys-directory keys \
  --binary /c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
```

Upload the extension to test DynamoDB endpoint:

```
npm run upload-ad-block -- --crx-directory build/ad-block-updater/ \
  --endpoint http://localhost:8000
```

Package the same extension and note version number increases by one:

```
npm run package-ad-block -- --keys-directory keys \
  --binary /c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe
```
