### PR TITLE
Remove vault-updater-path option, which is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,12 @@ After packaging a CRX file, you can upload it to Brave's S3 extensions bucket (`
 To upload a component extension, use the appropriate upload command. For example, to upload all of the Ad Block component extensions use the following command:
 
 ```bash
-yarn run upload-ad-block --crx-directory <crx-dir> --vault-updater-path <vu-dir> --endpoint <endpoint>
+yarn run upload-ad-block --crx-directory <crx-dir> --endpoint <endpoint>
 ```
 
 where:
 
 * `crx-dir` is the directory containing the CRX files to upload (as produced by running `package-ad-block`, for example)
-* `vu-dir` is the full path to the local vault-updater
 * `endpoint` is the DynamoDB endpoint (use http://localhost:8000 if setup locally)
 
 ### Theme Extensions
@@ -78,13 +77,12 @@ where:
 To upload all packaged theme extensions, use the following command:
 
 ```bash
-yarn run upload-themes --crx-directory <dir> --vault-updater-path <vu-dir> --endpoint <endpoint>
+yarn run upload-themes --crx-directory <dir> --endpoint <endpoint>
 ```
 
 where:
 
 * `dir` is the directory containing the CRX files to upload
-* `vu-dir` is the full path to the local vault-updater
 * `endpoint` is the DynamoDB endpoint (use http://localhost:8000 if setup locally)
 
 ### Importing Chrome Web Store extensions
@@ -92,12 +90,11 @@ where:
 To import the current list of supported Chrome Web Store extensions, use the following command:
 
 ```bash
-yarn run import-cws-components --vault-updater-path <vu-dir> --endpoint <endpoint>
+yarn run import-cws-components --endpoint <endpoint>
 ```
 
 where:
 
-* `vu-dir` is the full path to the local vault-updater
 * `endpoint` is the DynamoDB endpoint (use http://localhost:8000 if setup locally)
 
 This will download the supported extensions from the Chrome Web Store and upload them to S3.

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,6 +8,7 @@ const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const request = require('request')
+const s3 = require('s3-node-client')
 const unzip = require('unzip-crx-3')
 const AWS = require('aws-sdk')
 
@@ -15,13 +16,13 @@ const DynamoDBTableName = 'Extensions'
 
 const downloadExtensionFromCWS = (componentId, chromiumVersion, outputPath) => {
   const url = `https://clients2.google.com/service/update2/crx?response=redirect&prodversion=${chromiumVersion}&acceptformat=crx3&x=id%3D${componentId}%26uc`
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     request(url)
       .pipe(fs.createWriteStream(outputPath))
-      .on('finish', function () {
+      .on('finish', () => {
         resolve()
       })
-      .on('error', function () {
+      .on('error', () => {
         reject(new Error('Failed to make request to Chrome Web Store'))
       })
   })
@@ -77,47 +78,58 @@ const parseManifest = (manifestFile) => {
   return JSON.parse(json)
 }
 
-const uploadCRXFile = (endpoint, region, vaultUpdaterPath, crxFile, componentId) => {
+const uploadCRXFile = (endpoint, region, crxFile, componentId) => {
   const unzipDir = path.join('build', 'unzip', path.parse(crxFile).name)
 
   mkdirp.sync(unzipDir)
 
   unzip(crxFile, unzipDir).then(() => {
-    const manifest = path.join(unzipDir, 'manifest.json')
-    const data = parseManifest(manifest)
-
+    const data = parseManifest(path.join(unzipDir, 'manifest.json'))
     const id = componentId || getIDFromBase64PublicKey(data.key)
     const version = data.version
     const hash = generateSHA256HashOfFile(crxFile)
     const name = data.name
 
-    updateDynamoDB(endpoint, region, id, version, hash, name, false).then(() => {
-      const result = uploadExtension(vaultUpdaterPath, id, version, hash, name, crxFile)
-      if (result) {
-        console.log(result)
-      }
-    }).catch((err) => {
-      throw err
-    })
-
-    console.log(`Uploaded ${crxFile}`)
+    updateDynamoDB(endpoint, region, id, version, hash, name, false)
+      .then(() => uploadExtension(id, version, crxFile))
+      .then(() => console.log(`Uploaded ${crxFile}`))
+      .catch((err) => {
+        throw err
+      })
   })
 }
 
-const uploadExtension = (vaultUpdaterPath, id, version, hash, name, crxFile) => {
-  const script = path.join('node_modules', 'release-tools', 'bin', 'updateExtensions')
-
-  let args = ''
-
-  args += '--chromium 0.0.0.0 '
-  args += `--id ${id} `
-  args += `--location ${vaultUpdaterPath} `
-  args += `--path ${crxFile} `
-  args += `--version ${version} `
-  args += '--v 0'
-
-  process.env.S3_EXTENSIONS_BUCKET = 'brave-core-ext'
-  return childProcess.execSync(`node ${script} ${args}`).toString()
+const uploadExtension = (id, version, crxFile) => {
+  const S3_EXTENSIONS_BUCKET = process.env.S3_EXTENSIONS_BUCKET || 'brave-extensions'
+  const client = s3.createClient({
+    maxAsyncS3: 20,
+    s3RetryCount: 3,
+    s3RetryDelay: 1000,
+    multipartUploadThreshold: 20971520,
+    multipartUploadSize: 15728640,
+    // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#constructor-property
+    s3Options: {}
+  })
+  const componentFilename = `extension_${version.replace(/\./g, '_')}.crx`
+  return new Promise((resolve, reject) => {
+    var params = {
+      localFile: crxFile,
+      // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
+      s3Params: {
+        Bucket: S3_EXTENSIONS_BUCKET,
+        Key: `release/${id}/${componentFilename}`,
+        ACL: 'public-read'
+      }
+    }
+    const uploader = client.uploadFile(params)
+    uploader.on('error', (err) => {
+      console.error('Unable to upload:', err.stack, 'Do you have ~/.aws/credentials filled out?')
+      reject(new Error('Failed to upload extension to S3'))
+    })
+    uploader.on('end', (params) => {
+      resolve()
+    })
+  })
 }
 
 const createDynamoDBInstance = (endpoint, region) => {
@@ -218,6 +230,5 @@ module.exports = {
   getIDFromBase64PublicKey,
   installErrorHandlers,
   parseManifest,
-  uploadCRXFile,
-  uploadExtension
+  uploadCRXFile
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -177,34 +178,10 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "requires": {
-        "lodash": "4.17.10"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sdk": {
-      "version": "2.304.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.304.0.tgz",
-      "integrity": "sha512-jk+jJxPMB135iY58uF3LhxPTBUNXo7BigoB5orU8m7bxwQjsKOfCgzE7JP3imHLMgkEfTzJNxw9aNfLWFgBodQ==",
-      "requires": {
-        "buffer": "4.9.1",
-        "events": "1.1.1",
-        "ieee754": "1.1.8",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.19"
-      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -257,7 +234,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.3.0",
@@ -324,6 +302,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -331,16 +310,6 @@
     },
     "brave-chromium-themes": {
       "version": "github:brave/brave-chromium-themes#e9dc619d7ea5d1b13a911160b8af60ea069e3211"
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      }
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -373,7 +342,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -389,11 +359,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
-    },
-    "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "caseless": {
       "version": "0.12.0",
@@ -444,16 +409,6 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -462,7 +417,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -496,7 +452,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -574,11 +531,6 @@
         "which": "1.3.1"
       }
     },
-    "crypto": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
-      "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
-    },
     "crypto-browserify": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
@@ -606,11 +558,6 @@
       "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -738,6 +685,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -1127,11 +1075,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -1233,6 +1176,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
@@ -1290,7 +1234,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1323,7 +1268,8 @@
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -1355,6 +1301,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1441,7 +1388,8 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1491,6 +1439,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -1565,17 +1514,20 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -1596,6 +1548,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -1661,11 +1614,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1802,6 +1750,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -1914,18 +1863,6 @@
         "immediate": "3.0.6"
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -2011,6 +1948,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -2070,6 +2008,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "2.7.1",
         "is-builtin-module": "1.0.0",
@@ -2101,7 +2040,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -2124,6 +2064,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -2156,14 +2097,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -2210,6 +2143,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "1.3.2"
       }
@@ -2218,6 +2152,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
       "requires": {
         "pinkie-promise": "2.0.1"
       }
@@ -2225,7 +2160,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -2245,16 +2181,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2268,17 +2194,20 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -2525,25 +2454,6 @@
         }
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
-    },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -2562,21 +2472,6 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
-      }
-    },
-    "release-tools": {
-      "version": "github:brave/release-tools#a3a89d82b98db54e047ff27e518b063ab30aa1c6",
-      "requires": {
-        "async": "2.6.1",
-        "aws-sdk": "2.304.0",
-        "crypto": "0.0.3",
-        "glob": "7.1.3",
-        "request": "2.88.0",
-        "s3-node-client": "4.4.4",
-        "semver": "5.5.1",
-        "underscore": "1.9.1",
-        "xmldoc": "1.1.2",
-        "yargs": "7.1.0"
       }
     },
     "replace-in-file": {
@@ -2741,12 +2636,14 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -2910,12 +2807,14 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2976,6 +2875,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.0",
         "spdx-license-ids": "3.0.0"
@@ -2984,12 +2884,14 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "2.1.0",
         "spdx-license-ids": "3.0.0"
@@ -2998,7 +2900,8 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3068,6 +2971,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -3083,16 +2987,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -3309,11 +3206,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -3350,15 +3242,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "3.0.0",
         "spdx-expression-parse": "3.0.0"
@@ -3382,11 +3270,6 @@
       "requires": {
         "isexe": "2.0.0"
       }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -3413,6 +3296,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -3421,7 +3305,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "0.2.1",
@@ -3430,28 +3315,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
-      }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "9.0.7"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xmldoc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.2.tgz",
-      "integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
-      "requires": {
-        "sax": "1.2.1"
       }
     },
     "xregexp": {
@@ -3469,7 +3332,8 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yaku": {
       "version": "0.16.7",
@@ -3481,34 +3345,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "requires": {
-        "camelcase": "3.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "ad-block": "brave/ad-block",
+    "aws-sdk": "^2.338.0",
     "brave-chromium-themes": "brave/brave-chromium-themes",
     "https-everywhere-builder": "brave/https-everywhere-builder",
-    "release-tools": "brave/release-tools",
     "request": "^2.85.0",
+    "s3-node-client": "^4.4.4",
     "tracking-protection": "brave/tracking-protection",
     "unzip-crx-3": "^0.2.0"
   },

--- a/scripts/importCWSComponents.js
+++ b/scripts/importCWSComponents.js
@@ -10,7 +10,6 @@ const util = require('../lib/util')
 util.installErrorHandlers()
 
 commander
-  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data/')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
   .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
   .parse(process.argv)
@@ -30,7 +29,7 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
     util.downloadExtensionFromCWS(componentId, chromiumVersion, crxFile)
       .then(() => {
         console.log(`Downloaded component ${componentId} from Chrome Web Store`)
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxFile, componentId)
+        util.uploadCRXFile(commander.endpoint, commander.region, crxFile, componentId)
       })
   })
 })

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -154,6 +154,8 @@ if (!commander.binary) {
   throw new Error('Missing Chromium binary: --binary')
 }
 
-generateManifestFilesByComponentType(commander.type)
-getDATFileListByComponentType(commander.type)
-  .forEach(processDATFile.bind(null, commander.binary, commander.endpoint, commander.region, commander.type, keyParam))
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  generateManifestFilesByComponentType(commander.type)
+  getDATFileListByComponentType(commander.type)
+    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint, commander.region, commander.type, keyParam))
+})

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -136,6 +136,8 @@ if (!commander.binary) {
   throw new Error('Missing Chromium binary: --binary')
 }
 
-packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
-packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
-packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)
+})

--- a/scripts/packageThemes.js
+++ b/scripts/packageThemes.js
@@ -81,4 +81,6 @@ if (!commander.binary) {
 
 const outputDir = path.join('build', 'themes')
 
-generateCRXFiles(commander.binary, commander.endpoint, commander.region, outputDir)
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  generateCRXFiles(commander.binary, commander.endpoint, commander.region, outputDir)
+})

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -131,6 +131,8 @@ if (!commander.binary) {
   throw new Error('Missing Chromium binary: --binary')
 }
 
-packageTorClient(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
-packageTorClient(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
-packageTorClient(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  packageTorClient(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
+  packageTorClient(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
+  packageTorClient(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)
+})

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -10,7 +10,6 @@ const util = require('../lib/util')
 util.installErrorHandlers()
 
 commander
-  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data')
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
   .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|tracking-protection-updater)$/i, 'ad-block-updater')
@@ -32,10 +31,10 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
+        util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
+    util.uploadCRXFile(commander.endpoint, commander.region, crxParam)
   }
 })

--- a/scripts/uploadIpfsDaemon.js
+++ b/scripts/uploadIpfsDaemon.js
@@ -10,7 +10,6 @@ const util = require('../lib/util')
 util.installErrorHandlers()
 
 commander
-  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data/')
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
@@ -31,10 +30,10 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
+        util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
+    util.uploadCRXFile(commander.endpoint, commander.region, crxParam)
   }
 })

--- a/scripts/uploadThemes.js
+++ b/scripts/uploadThemes.js
@@ -10,7 +10,6 @@ const util = require('../lib/util')
 util.installErrorHandlers()
 
 commander
-  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data/')
   .option('-c, --crx-directory <dir>', 'crx directory')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
   .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
@@ -24,7 +23,7 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const outputDir = path.join('build', 'themes')
   fs.readdirSync(commander.crxDirectory).forEach(file => {
     if (path.extname(file) === '.crx') {
-      util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(outputDir, file))
+      util.uploadCRXFile(commander.endpoint, commander.region, path.join(outputDir, file))
     }
   })
 })

--- a/scripts/uploadTorClient.js
+++ b/scripts/uploadTorClient.js
@@ -10,7 +10,6 @@ const util = require('../lib/util')
 util.installErrorHandlers()
 
 commander
-  .option('-v, --vault-updater-path <dir>', 'directory containing the brave/vault-updater/data/')
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
@@ -31,10 +30,10 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   if (fs.lstatSync(crxParam).isDirectory()) {
     fs.readdirSync(crxParam).forEach(file => {
       if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, path.join(crxParam, file))
+        util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
       }
     })
   } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, commander.vaultUpdaterPath, crxParam)
+    util.uploadCRXFile(commander.endpoint, commander.region, crxParam)
   }
 })


### PR DESCRIPTION
Fixes #30

Eliminates the `--vault-updater-path` option from our scripts, since it's no longer needed. Dropping the option itself was simple, but release-tools had a lot of assumptions about vault-updater baked in. Seemed easiest to just drop release-tools as a dependency and migrate the S3 upload code (essentially just a single function) to our utility script.