### PR TITLE
migrate tracking protection to local data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The currently supported component extension types are:
 * `ad-block`
 * `https-everywhere`
 * `tor-client`
-* `tracking-protection`
+* `local-data-files` (formerly `tracking-protection`)
 
 ### Theme Extensions
 

--- a/manifests/local-data-files-updater/default-manifest.json
+++ b/manifests/local-data-files-updater/default-manifest.json
@@ -1,7 +1,7 @@
 {
-  "description": "Brave Tracking Protection Updater extension",
+  "description": "Brave Local Data Files Updater extension",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs4TIQXRCftLpGmQZxmm6AU8pqGKLoDyi537HGQyRKcK7j/CSXCf3vwJr7xkV72p7bayutuzyNZ3740QxBPiesfBOp8bBb8d2VgTHP3b+SuNmK/rsSRsMRhT05x8AAr/7ab6U3rW0Gsalm2653xnnQS8vt0s62xQTmC+UMXowaSLUZ0Be/TOu6lHZhOeo0NBMKc6PkOu0R1EEfP7dJR6SM/v4dBUBZ1HXcuziVbCXVyU51opZCMjlxyUlQR9pTGk+Zh5sDn1Vw1MwLnWiEfQ4EGL1V7GeI4vgLoOLgq7tmhEratHGCfC1IHm9luMACRr/ybMI6DQJOvgBvecb292FxQIDAQAB",
   "manifest_version": 2,
-  "name": "Brave Tracking Protection Updater",
+  "name": "Brave Local Data Files Updater",
   "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "ad-block": "brave/ad-block",
-    "aws-sdk": "^2.338.0",
+    "ajv": "^5.5.2",
+    "aws-sdk": "^2.392.0",
     "brave-chromium-themes": "brave/brave-chromium-themes",
     "https-everywhere-builder": "brave/https-everywhere-builder",
     "request": "^2.85.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "data-files-ad-block": "npm run --prefix ./node_modules/ad-block data-files",
     "data-files-https-everywhere": "npm run --prefix ./node_modules/https-everywhere-builder build",
     "data-files-tracking-protection": "cd ./node_modules/tracking-protection/scripts && node ./genDataFile",
+    "data-files-local-data-files": "npm run data-files-tracking-protection",
     "lint": "standard",
     "import-cws-components": "node ./scripts/importCWSComponents",
     "package-ad-block": "node ./scripts/packageComponent --type ad-block-updater",
@@ -33,13 +34,13 @@
     "package-themes": "node ./scripts/packageThemes",
     "package-tor-client": "node ./scripts/packageTorClient",
     "package-ipfs-daemon": "node ./scripts/packageIpfsDaemon",
-    "package-tracking-protection": "node ./scripts/packageComponent --type tracking-protection-updater",
+    "package-local-data-files": "node ./scripts/packageComponent --type local-data-files-updater",
     "upload-ad-block": "node ./scripts/uploadComponent --type ad-block-updater",
     "upload-https-everywhere": "node ./scripts/uploadComponent --type https-everywhere-updater",
     "upload-ipfs-daemon": "node ./scripts/uploadIpfsDaemon",
     "upload-themes": "node ./scripts/uploadThemes",
     "upload-tor-client": "node ./scripts/uploadTorClient",
-    "upload-tracking-protection": "node ./scripts/uploadComponent --type tracking-protection-updater"
+    "upload-local-data-files": "node ./scripts/uploadComponent --type local-data-files-updater"
   },
   "repository": {
     "type": "git",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -47,7 +47,7 @@ const getDATFileVersionByComponentType = (componentType) => {
         .match(/DATA_FILE_VERSION\s*=\s*(\d+)/)[1]
     case 'https-everywhere-updater':
       return '6.0'
-    case 'tracking-protection-updater':
+    case 'local-data-files-updater':
       return '1'
     default:
       throw new Error('Unrecognized component extension type: ' + componentType)
@@ -60,7 +60,7 @@ const generateManifestFilesByComponentType = (componentType) => {
       childProcess.execSync(`npm run --prefix ${path.join('node_modules', 'ad-block')} manifest-files`)
       break
     case 'https-everywhere-updater':
-    case 'tracking-protection-updater':
+    case 'local-data-files-updater':
       // TODO(emerick): Make these work like ad-block (i.e., update
       // the corresponding repos with a script to generate the
       // manifest and then call that script here)
@@ -75,7 +75,7 @@ const getManifestsDirByComponentType = (componentType) => {
     case 'ad-block-updater':
       return path.join('node_modules', 'ad-block', 'out')
     case 'https-everywhere-updater':
-    case 'tracking-protection-updater':
+    case 'local-data-files-updater':
       // TODO(emerick): Make these work like ad-block
       return path.join('manifests', componentType)
     default:
@@ -105,7 +105,7 @@ const getDATFileListByComponentType = (componentType) => {
         }, [])
     case 'https-everywhere-updater':
       return path.join('node_modules', 'https-everywhere-builder', 'out', 'httpse.leveldb.zip').split()
-    case 'tracking-protection-updater':
+    case 'local-data-files-updater':
       return path.join('node_modules', 'tracking-protection', 'data', 'TrackingProtection.dat').split()
     default:
       throw new Error('Unrecognized component extension type: ' + componentType)
@@ -135,7 +135,7 @@ commander
   .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
   .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
   .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|tracking-protection-updater)$/i, 'ad-block-updater')
+  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater)$/i, 'ad-block-updater')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
   .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
   .parse(process.argv)

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -12,7 +12,7 @@ util.installErrorHandlers()
 commander
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
-  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|tracking-protection-updater)$/i, 'ad-block-updater')
+  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater)$/i, 'ad-block-updater')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
   .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
   .parse(process.argv)


### PR DESCRIPTION
In preparation for adding additional datasets under 1 `.crx` file, we are migrating the tracking protection component to a more generic "local data files" component. Currently it only contains the tracking protection data, but future versions may contain other datafiles for other Brave services.

The brave-core piece of this is https://github.com/brave/brave-core/pull/1279