### PR TITLE
Issue 48: ExtensionWhitelist should use the default manifest

### DIFF
--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -87,6 +87,7 @@ const getNormalizedDATFileName = (datFileName) =>
   datFileName === 'ABPFilterParserData' ||
   datFileName === 'httpse.leveldb' ||
   datFileName === 'TrackingProtection' ||
+  datFileName === 'ExtensionWhitelist' ||
   datFileName === 'AutoplayWhitelist' ? 'default' : datFileName
 
 const getOriginalManifest = (componentType, datFileName) => {


### PR DESCRIPTION
fix https://github.com/brave/brave-core-crx-packager/issues/48

### Description

`Local-Data` extension was failing the build with this error:

```
13:57:34 
13:57:35 Unhandled rejection: { Error: ENOENT: no such file or directory, open 'manifests/local-data-files-updater/ExtensionWhitelist-manifest.json'
13:57:35     at Object.openSync (fs.js:450:3)
13:57:35     at Object.readFileSync (fs.js:350:35)
13:57:35     at Object.parseManifest (/Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish-dev/lib/util.js:77:19)
13:57:35     at processDATFile (/Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish-dev/scripts/packageComponent.js:121:31)
13:57:35     at Array.forEach (<anonymous>)
13:57:35     at util.createTableIfNotExists.then (/Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish-dev/scripts/packageComponent.js:163:6)
```

The `ExtensionWhitelist` should use the default manifest and not `ExtensionWhitelist-manifest`