### PR TITLE
Update package-lock.json for new https-everywhere-builder deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,6 +1367,8 @@
       "requires": {
         "commander": "^2.11.0",
         "level": "^5.0.1",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.7",
         "s3-client": "^4.4.2"
       }
     },
@@ -2524,6 +2526,24 @@
         "uuid": "^3.3.2"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2880,6 +2900,11 @@
           "dev": true
         }
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "streamsink": {
       "version": "1.2.0",


### PR DESCRIPTION
Fixes #70 

This PR is a result of running `npm install` twice in the repo.

To test this branch, I:

1. deleted the `node_modules` directory
2. ran `npm install`
3. verified `package-lock.json` is unchanged
4. ran `npm run data-files-https-everywhere`