### PR TITLE
JSON adblock resources support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/uBlock"]
+	path = submodules/uBlock
+	url = https://github.com/brave/uBlock

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,11 @@
       }
     },
     "adblock-rs": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.1.28.tgz",
-      "integrity": "sha512-5Jrn+Dddj7SzwECyyxByMiNQVEgne5IG+jAep/esgZnv+Z6JwnuEeHYeh/TziOMKQNJKe2tNh6wHY6T000e9Gg==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.1.37.tgz",
+      "integrity": "sha512-gQeelsYQSeEt5NigIhdMm2KSyASgYZfj2Y6CItRWe8awzZ9yriN7+Js91FN+30NEiAEOjQPiJiXnepvV48iwJw==",
       "requires": {
-        "neon-cli": "^0.2.0"
+        "neon-cli": "0.3.1"
       }
     },
     "ajv": {
@@ -1263,9 +1263,9 @@
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1861,16 +1861,16 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "neon-cli": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.2.0.tgz",
-      "integrity": "sha512-IsrxCyUcuAyWiq4Z+JnTXrjurj2SAL2VtWnCXS8iBYGJeIs1NIhFuLaM6fe7+rOyFfDcqUUTWGxZmkvUqwweRA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.3.1.tgz",
+      "integrity": "sha512-OBrJbDD0BNDPxWwh88kWd2dJkXWEZ/mrCPF/ADrsLgHmF2qDdbXagli48I7yVl1ngMtItrvI7JqBeiNQNtN1ww==",
       "requires": {
         "chalk": "~2.1.0",
         "command-line-args": "^4.0.2",
         "command-line-commands": "^2.0.0",
         "command-line-usage": "^4.0.0",
         "git-config": "0.0.7",
-        "handlebars": "^4.0.3",
+        "handlebars": "^4.1.0",
         "inquirer": "^3.0.6",
         "mkdirp": "^0.5.1",
         "quickly-copy-file": "^1.0.0",
@@ -3087,13 +3087,21 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true
+        }
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "ad-block": "brave/ad-block",
-    "adblock-rs": "^0.1.28",
+    "adblock-rs": "^0.1.36",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",


### PR DESCRIPTION
Similar to #73, but using the newer `web_accessible_resources` and `scriptlets.js` resources from the uBlock Origin repo.

Brave's audited [fork of uBlock Origin](https://github.com/brave/uBlock) is added as a submodule.