### PR TITLE
Support NTP sponsored images component

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "ad-block": "brave/ad-block",
     "adblock-rs": "^0.1.36",
+    "adm-zip": "^0.4.13",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",
@@ -36,6 +37,7 @@
     "data-files-autoplay-whitelist": "npm run --prefix ./node_modules/autoplay-whitelist data-files",
     "data-files-extension-whitelist": "npm run --prefix ./node_modules/extension-whitelist data-files",
     "data-files-local-data-files": "npm run data-files-tracking-protection && npm run data-files-autoplay-whitelist && npm run data-files-extension-whitelist",
+    "generate-ntp-sponsored-images": "node scripts/generateNTPSponsoredImages.js",
     "lint": "standard",
     "import-cws-components": "node ./scripts/importCWSComponents",
     "package-ethereum-remote-client": "node ./scripts/packageComponent --type ethereum-remote-client",
@@ -44,13 +46,15 @@
     "package-tor-client": "node ./scripts/packageTorClient",
     "package-ipfs-daemon": "node ./scripts/packageIpfsDaemon",
     "package-local-data-files": "node ./scripts/packageComponent --type local-data-files-updater",
+    "package-ntp-sponsored-images": "node ./scripts/packageNTPSponsoredImagesComponents",
     "upload-ethereum-remote-client": "node ./scripts/uploadComponent --type ethereum-remote-client",
     "upload-ad-block": "node ./scripts/uploadComponent --type ad-block-updater",
     "upload-ad-block-raw": "node ./scripts/uploadRawAdblock",
     "upload-https-everywhere": "node ./scripts/uploadComponent --type https-everywhere-updater",
     "upload-ipfs-daemon": "node ./scripts/uploadIpfsDaemon",
     "upload-tor-client": "node ./scripts/uploadTorClient",
-    "upload-local-data-files": "node ./scripts/uploadComponent --type local-data-files-updater"
+    "upload-local-data-files": "node ./scripts/uploadComponent --type local-data-files-updater",
+    "upload-ntp-sponsored-images-components": "node ./scripts/uploadComponent --type ntp-sponsored-images"
   },
   "repository": {
     "type": "git",

--- a/scripts/generateNTPSponsoredImages.js
+++ b/scripts/generateNTPSponsoredImages.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const path = require('path')
+const mkdirp = require('mkdirp')
+const fs = require('fs-extra')
+const request = require('request')
+const commander = require('commander')
+const admZip = require('adm-zip')
+
+const generateNTPSponsoredImages = (dataUrl) => {
+  const targetResourceDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources')
+  mkdirp.sync(targetResourceDir)
+
+  const dataZipFile = path.join(targetResourceDir, 'data.zip')
+  request(dataUrl)
+    .pipe(fs.createWriteStream(dataZipFile))
+    .on('finish', () => {
+      let zip = new admZip(dataZipFile)
+      zip.extractAllTo(targetResourceDir)
+      console.log(`Downloaded to ${dataZipFile} and unzipped`)
+    })
+}
+
+commander
+  .option('-d, --data-url <url>', 'url that refers to data that has ntp sponsored images')
+  .parse(process.argv)
+
+generateNTPSponsoredImages(commander.dataUrl)

--- a/scripts/packageNTPSponsoredImagesComponents.js
+++ b/scripts/packageNTPSponsoredImagesComponents.js
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const childProcess = require('child_process')
+const commander = require('commander')
+const fs = require('fs-extra')
+const mkdirp = require('mkdirp')
+const path = require('path')
+const replace = require('replace-in-file')
+const util = require('../lib/util')
+
+const getComponentDataList = () => {
+  return [
+      { locale: 'en-US',
+        key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwnu+bh/TJ1+SvCtc4aRHC92fjS167f5uZKwgZ/YcvRK0y5BDiiWu/owQYIgcDLBYvBrJbpRg+3jyEYMdMYsCgoj6l+OZXeTGHXKGG3HeBHpu4mXArj3ohG3ce3P4SlpuuOI4qhtDsu1t7n/fP4Jm+vPMviaeJCfxVMVQEllol7ReMFpmVcpqUmiFMoF6Oop2IuZ7iSv+r/OU8dhWPO+0ghZ9b8S1D8Yr8P3ZrywUcO4vi26e5Hw8jHD1OdOuNbNYiwnqCzR4TaI4eRpPrMYBJ5MpQGKR/sxjByvdyE4iR7+4CCHXcaADY8VRcxlzjWsK7ZcSqpAdWxL5wEnWjnwe9QIDAQAB',
+        id: 'jfmhfclplhdedolodknnpdpjedaojkgj' },
+  ]
+}
+
+const stageFiles = (locale, version, outputDir) => {
+  // Copy resources and manifest file to outputDir.
+  // Copy resource files
+  const resourceDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources', locale, '/')
+  console.log('copy dir:', resourceDir, ' to:', outputDir)
+  fs.copySync(resourceDir, outputDir)
+
+  // Fix up the manifest version
+  const originalManifest = getOriginalManifest(locale)
+  const outputManifest = path.join(outputDir, 'manifest.json')
+  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
+  const replaceOptions = {
+    files: outputManifest,
+    from: /0\.0\.0/,
+    to: version
+  }
+  fs.copyFileSync(originalManifest, outputManifest)
+  replace.sync(replaceOptions)
+}
+
+const generateManifestFile = (componentData) => {
+  const manifestFile = getOriginalManifest(componentData.locale)
+  const manifestContent = {
+    description: 'Brave NTP sponsored images component',
+    key: componentData.key,
+    manifest_version: 2,
+    name: 'Brave NTP sponsored images',
+    version: '0.0.0'
+  }
+  fs.writeFileSync(manifestFile, JSON.stringify(manifestContent))
+}
+
+const generateManifestFiles = () => {
+  getComponentDataList().forEach(generateManifestFile)
+}
+
+const getManifestsDir = () => {
+  const targetResourceDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'manifiest-files')
+  mkdirp.sync(targetResourceDir)
+  return targetResourceDir
+}
+
+const getOriginalManifest = (locale) => {
+  return path.join(getManifestsDir(), `${locale}-manifest.json`)
+}
+
+const generateCRXFile = (binary, endpoint, region, keyDir, componentData) => {
+  const originalManifest = getOriginalManifest(componentData.locale)
+  const locale = componentData.locale
+  const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images')
+  const stagingDir = path.join(rootBuildDir, 'staging', locale)
+  const crxOutputDir = path.join(rootBuildDir, 'output')
+  mkdirp.sync(stagingDir)
+  mkdirp.sync(crxOutputDir)
+  util.getNextVersion(endpoint, region, componentData.id).then((version) => {
+    const crxFile = path.join(crxOutputDir, `ntp-sponsored-images-${locale}.crx`)
+    const privateKeyFile = path.join(keyDir, `ntp-sponsored-images-${locale}.pem`)
+    stageFiles(locale, version, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+util.installErrorHandlers()
+
+commander
+  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
+  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
+  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
+  .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
+  .parse(process.argv)
+
+let keyDir = ''
+if (fs.existsSync(commander.keysDirectory)) {
+  keyDir = commander.keysDirectory
+} else {
+  throw new Error('Missing or invalid private key directory')
+}
+
+if (!commander.binary) {
+  throw new Error('Missing Chromium binary: --binary')
+}
+
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  generateManifestFiles()
+  getComponentDataList().forEach(generateCRXFile.bind(null, commander.binary, commander.endpoint, commander.region, keyDir))
+})

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -12,7 +12,7 @@ util.installErrorHandlers()
 commander
   .option('-d, --crx-directory <dir>', 'directory containing multiple crx files to upload')
   .option('-f, --crx-file <file>', 'crx file to upload', 'extension.crx')
-  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater|ethereum-remote-client)$/i, 'ad-block-updater')
+  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater|ethereum-remote-client|ntp-sponsored-images)$/i, 'ad-block-updater')
   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
   .option('-r, --region <region>', 'The AWS region to use', 'us-east-2')
   .parse(process.argv)


### PR DESCRIPTION
This PR create only sample en-US localed component crx for test purpose.
Later, this will create components all supported all locales.

To generate data set:
  - npm run generate-ntp-sponsored-images -- --data-url="data-url that refers zipped data file"
  - data set is stored at ./build/ntp-sponsored-images/resources

To package crx files:
  - npm run package-ntp-sponsored-images -- --binary "chromium bin path"  --keys-directory "dirs that stores private files"
  - crx files are stored at ./build/ntp-sponsored-images/output/ntp-sponsored-images-en-US.crx (in en-US case)

To upload crx files:
  - npm run upload-ntp-sponsored-images-components -- --crx-directory "above outout crx files directory"