### PR TITLE
Modify crx uploading logic

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -83,17 +83,38 @@ const uploadCRXFile = (endpoint, region, crxFile, componentId) => {
 
   mkdirp.sync(unzipDir)
 
-  unzip(crxFile, unzipDir).then(() => {
+  return unzip(crxFile, unzipDir).then(() => {
     const data = parseManifest(path.join(unzipDir, 'manifest.json'))
     const id = componentId || getIDFromBase64PublicKey(data.key)
     const version = data.version
     const hash = generateSHA256HashOfFile(crxFile)
     const name = data.name
 
-    updateDynamoDB(endpoint, region, id, version, hash, name, false)
-      .then(() => uploadExtension(id, version, crxFile))
+    return uploadExtension(id, version, crxFile)
       .then(() => console.log(`Uploaded ${crxFile}`))
       .catch((err) => {
+        console.log(`Uploading ${crxFile} is failed.`)
+        throw err
+      })
+  })
+}
+
+const updateDBForCRXFile = (endpoint, region, crxFile, componentId) => {
+  const unzipDir = path.join('build', 'unzip', path.parse(crxFile).name)
+
+  mkdirp.sync(unzipDir)
+
+  return unzip(crxFile, unzipDir).then(() => {
+    const data = parseManifest(path.join(unzipDir, 'manifest.json'))
+    const id = componentId || getIDFromBase64PublicKey(data.key)
+    const version = data.version
+    const hash = generateSHA256HashOfFile(crxFile)
+    const name = data.name
+
+    return updateDynamoDB(endpoint, region, id, version, hash, name, false)
+      .then(() => console.log(`Updated DB for ${crxFile}`))
+      .catch((err) => {
+        console.log(`Updating DB for ${crxFile} is failed.`)
         throw err
       })
   })
@@ -232,5 +253,6 @@ module.exports = {
   getIDFromBase64PublicKey,
   installErrorHandlers,
   parseManifest,
-  uploadCRXFile
+  uploadCRXFile,
+  updateDBForCRXFile
 }

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -27,14 +27,29 @@ if (fs.existsSync(commander.crxFile)) {
   throw new Error('Missing or invalid crx file/directory', commander.crxFile, commander.crxDirectory)
 }
 
-util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  if (fs.lstatSync(crxParam).isDirectory()) {
-    fs.readdirSync(crxParam).forEach(file => {
-      if (path.parse(file).ext === '.crx') {
-        util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
-      }
-    })
-  } else {
-    util.uploadCRXFile(commander.endpoint, commander.region, crxParam)
-  }
+let uploadJobs = []
+if (fs.lstatSync(crxParam).isDirectory()) {
+  fs.readdirSync(crxParam).forEach(file => {
+    if (path.parse(file).ext === '.crx') {
+      uploadJobs.push(util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file)))
+    }
+  })
+} else {
+  uploadJobs.push(util.uploadCRXFile(commander.endpoint, commander.region, crxParam))
+}
+
+Promise.all(uploadJobs).then(() => {
+  util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+    if (fs.lstatSync(crxParam).isDirectory()) {
+      fs.readdirSync(crxParam).forEach(file => {
+        if (path.parse(file).ext === '.crx') {
+          util.updateDBForCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
+        }
+      })
+    } else {
+      util.updateDBForCRXFile(commander.endpoint, commander.region, crxParam)
+    }
+  })
+}).catch((err) => {
+  console.error('Caught exception:', err)
 })


### PR DESCRIPTION
DB should be updated after crx uploading is done.
If DB is updated first, update server could be in inconsistent
state before upload is finished.

According to the log (https://ci.brave.com/view/all-extensions/job/brave-core-ext-ntp-sponsored-update-publish-dev/40/console), crx is uploaded first and then db is updated.

fix https://github.com/brave/brave-browser/issues/8037