### PR TITLE
Support region subset packaging for SI component

### DIFF
--- a/scripts/generateNTPSponsoredImages.js
+++ b/scripts/generateNTPSponsoredImages.js
@@ -97,11 +97,24 @@ function downloadForRegion (jsonFileUrl, targetResourceDir) {
   })
 }
 
-async function generateNTPSponsoredImages (dataUrl) {
+function getTargetRegionList(targetRegions, excludedTargetRegions) {
+  targetRegionList = []
+  if (targetRegions === '')
+    targetRegionList = getRegionList()
+  else
+    targetRegionList = targetRegions.split(',')
+
+  if (excludedTargetRegions === '')
+    return targetRegionList
+
+  return targetRegionList.filter(region => !excludedTargetRegions.includes(region))
+}
+
+async function generateNTPSponsoredImages (dataUrl, targetRegions, excludedTargetRegions) {
   const rootResourceDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources')
   mkdirp.sync(rootResourceDir)
 
-  for (const region of getRegionList()) {
+  for (const region of getTargetRegionList(targetRegions, excludedTargetRegions)) {
     console.log(`Downloading ${region}...`)
     const targetResourceDir = path.join(rootResourceDir, region)
     mkdirp.sync(targetResourceDir)
@@ -112,6 +125,19 @@ async function generateNTPSponsoredImages (dataUrl) {
 
 commander
   .option('-d, --data-url <url>', 'url that refers to data that has ntp sponsored images')
+  .option('-t, --target-regions <regions>', 'Comma separated list of regions that should generate SI component. For example: "AU,US,GB"', '')
+  .option('-u, --excluded-target-regions <regions>', 'Comma separated list of regions that should not generate SI component. For example: "AU,US,GB"', '')
   .parse(process.argv)
 
-generateNTPSponsoredImages(commander.dataUrl)
+let targetRegions = ""
+if (commander.targetRegions) {
+  // Stripping unrelated chars.
+  // Only upper case and commas are allowed.
+  targetRegions = commander.targetRegions.replace(/[^A-Z,]/g, "")
+}
+let excludedTargetRegions = ""
+if (commander.excludedTargetRegions) {
+  excludedTargetRegions = commander.excludedTargetRegions.replace(/[^A-Z,]/g, "")
+}
+
+generateNTPSponsoredImages(commander.dataUrl, targetRegions, excludedTargetRegions)


### PR DESCRIPTION
Added target regions and excluded target regions list option.
With these two options, we don't need to update whole region's component when we want to update only some regions.
Related devops issue: https://github.com/brave/devops/issues/3038

If `AU,GB,US` is set as target-region, only these three region's components are updated.
If `IN` is set as a excluded-target-region, all regions except `IN` region are updated.

Fix https://github.com/brave/brave-browser/issues/8173