### PR TITLE
Pull adblock resources from brave/adblock-resources

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -2,11 +2,14 @@ const { uBlockResources } = require('adblock-rs')
 
 const path = require('path')
 const fs = require('fs')
+const request = require('request')
 
 const uBlockLocalRoot = 'submodules/uBlock'
 const uBlockWebAccessibleResources = path.join(uBlockLocalRoot, 'src/web_accessible_resources')
 const uBlockRedirectEngine = path.join(uBlockLocalRoot, 'src/js/redirect-engine.js')
 const uBlockScriptlets = path.join(uBlockLocalRoot, 'assets/resources/scriptlets.js')
+
+const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/dist/resources.json'
 
 /**
  * Returns a promise that generates a resources file from the uBlock Origin
@@ -14,13 +17,23 @@ const uBlockScriptlets = path.join(uBlockLocalRoot, 'assets/resources/scriptlets
  */
 const generateResourcesFile = (outLocation) => {
   return new Promise((resolve, reject) => {
-    const jsonData = JSON.stringify(uBlockResources(
+    let resourceData = uBlockResources(
       uBlockWebAccessibleResources,
       uBlockRedirectEngine,
       uBlockScriptlets
-    ))
-    fs.writeFileSync(outLocation, jsonData, 'utf8')
-    resolve()
+    )
+    request.get(braveResourcesUrl, function (error, response, body) {
+      if (error) {
+        reject(new Error(`Request error: ${error}`))
+      }
+      if (response.statusCode !== 200) {
+        reject(new Error(`Error status code ${response.statusCode} returned for URL: ${braveResourcesUrl}`))
+      }
+      const braveResources = JSON.parse(body)
+      resourceData.push(...braveResources)
+      fs.writeFileSync(outLocation, JSON.stringify(resourceData), 'utf8')
+      resolve()
+    })
   })
 }
 


### PR DESCRIPTION
I've created the new https://github.com/brave/adblock-resources repository where Brave can host its own adblock resources for use with adblock-rust. There are no resources hosted there as of yet, but @pes10k is planning to push one soon.

There is a verification script as part of that repository which ensures the resources are in the correct format to be accepted by adblock-rust. This PR enables the CRX packager to pull resources from that repository in addition to the existing resources from the uBO fork.