### PR TITLE
Fix 123: Add tags to extensions uploaded to the S3 bucket

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -54,6 +54,7 @@ const getIDFromBase64PublicKey = (key) => {
   })
 }
 
+// Update getPreviousVersion if this code is updated
 const incrementVersion = (version) => {
   const versionParts = version.split('.')
   versionParts[versionParts.length - 1]++
@@ -90,7 +91,7 @@ const uploadCRXFile = (endpoint, region, crxFile, componentId) => {
     const hash = generateSHA256HashOfFile(crxFile)
     const name = data.name
 
-    return uploadExtension(id, version, crxFile)
+    return uploadExtension(name, id, version, crxFile)
       .then(() => console.log(`Uploaded ${crxFile}`))
       .catch((err) => {
         console.log(`Uploading ${crxFile} is failed.`)
@@ -120,8 +121,17 @@ const updateDBForCRXFile = (endpoint, region, crxFile, componentId) => {
   })
 }
 
-const uploadExtension = (id, version, crxFile) => {
+// Update incrementVersion if this code is updated
+const getPreviousVersion = (version) => {
+  const versionParts = version.split('.')
+  versionParts[versionParts.length - 1]--
+  return versionParts.join('.')
+}
+
+const uploadExtension = (name, id, version, crxFile) => {
   const S3_EXTENSIONS_BUCKET = process.env.S3_EXTENSIONS_BUCKET || 'brave-core-ext'
+  // Using aws_s3 because s3-node-client does not support updating tags
+  const aws_s3 = new AWS.S3();
   const client = s3.createClient({
     maxAsyncS3: 20,
     s3RetryCount: 3,
@@ -134,6 +144,10 @@ const uploadExtension = (id, version, crxFile) => {
     }
   })
   const componentFilename = `extension_${version.replace(/\./g, '_')}.crx`
+  const componentName = `${name.replace(/\s/g, '-')}`
+  const previousComponentFilename = `extension_${getPreviousVersion(version).replace(/\./g, '_')}.crx`
+  const latestVersionTag = `version=${componentName}/latest`
+  const tag = `${componentName}=${version.replace(/\./g, '.')}&${latestVersionTag}`
   return new Promise((resolve, reject) => {
     var params = {
       localFile: crxFile,
@@ -141,7 +155,8 @@ const uploadExtension = (id, version, crxFile) => {
       s3Params: {
         Bucket: S3_EXTENSIONS_BUCKET,
         Key: `release/${id}/${componentFilename}`,
-        ACL: 'public-read'
+        ACL: 'public-read',
+        Tagging: tag
       }
     }
     const uploader = client.uploadFile(params)
@@ -150,7 +165,27 @@ const uploadExtension = (id, version, crxFile) => {
       reject(new Error('Failed to upload extension to S3'))
     })
     uploader.on('end', (params) => {
-      resolve()
+      console.log(`Added tags to ${id}/${componentFilename}`)
+      var params = {
+        Bucket: S3_EXTENSIONS_BUCKET,
+        Key: `release/${id}/${previousComponentFilename}`,
+        Tagging: {
+          TagSet: [
+            {
+              Key: `${componentName}`,
+              Value: `${getPreviousVersion(version).replace(/\./g, '.')}`
+            }
+          ]
+        }
+      }
+      aws_s3.putObjectTagging(params, function(err, data) {
+        if (err) {
+          console.error(err, err.stack)
+          reject(new Error('Failed to upload extension to S3'))
+        }
+        console.log(`Updated tags for ${id}/${previousComponentFilename}`)
+        resolve()
+      })
     })
   })
 }


### PR DESCRIPTION
Fix #123 

## Description

To get the number of downloads per component and version, we need to add tags to all the components uploaded to the S3 bucket. 

Tag is of the form `component-name=component-name` and `version=component-name/latest`. 