### PR TITLE
Update adblock-rs to 0.2.9 to fix Lithuanian list URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -256,9 +256,9 @@
       }
     },
     "adblock-rs": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.2.8.tgz",
-      "integrity": "sha512-xtaGH92FCma7s2V82Cy1+9PpEaRV/ec1q0O+K7nPHhji/lK8YAvdKHlnWF6dw442+feOc5B6VW1hFOpp1aGFcQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.2.9.tgz",
+      "integrity": "sha512-EhexCcSkJQG6MR+4LFzOM9GFagszAfholdQCdDeprtz9rb9CO3eUHG0jeVtndRI9bw+D7Lko9NbDvhbBD9CnGw==",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -6352,9 +6352,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
-      "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
+      "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "ad-block": "brave/ad-block",
-    "adblock-rs": "^0.2.8",
+    "adblock-rs": "^0.2.9",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",


### PR DESCRIPTION
Currently unable to run due to the old Lithuanian list URL (margevicius.lt) having an invalid certificate. 0.2.9 contains [this commit](https://github.com/brave/adblock-rust/commit/73786e56b545c44920923cfdd4656edbd3e4744c) which should resolve the issue.