### PR TITLE
 Fix #129: Fix tagging for super referrers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,6 +13,7 @@ const unzip = require('unzip-crx-3')
 const AWS = require('aws-sdk')
 
 const DynamoDBTableName = 'Extensions'
+const FirstVersion = "1.0.0"
 
 const downloadExtensionFromCWS = (componentId, chromiumVersion, outputPath) => {
   const url = `https://clients2.google.com/service/update2/crx?response=redirect&prodversion=${chromiumVersion}&acceptformat=crx3&x=id%3D${componentId}%26uc`
@@ -123,6 +124,10 @@ const updateDBForCRXFile = (endpoint, region, crxFile, componentId) => {
 
 // Update incrementVersion if this code is updated
 const getPreviousVersion = (version) => {
+  if (version == FirstVersion) {
+    // This is the first version
+    return FirstVersion
+  }
   const versionParts = version.split('.')
   versionParts[versionParts.length - 1]--
   return versionParts.join('.')
@@ -146,8 +151,11 @@ const uploadExtension = (name, id, version, crxFile) => {
   const componentFilename = `extension_${version.replace(/\./g, '_')}.crx`
   const componentName = `${name.replace(/\s/g, '-')}`
   const previousComponentFilename = `extension_${getPreviousVersion(version).replace(/\./g, '_')}.crx`
-  const latestVersionTag = `version=${componentName}/latest`
-  const tag = `${componentName}=${version.replace(/\./g, '.')}&${latestVersionTag}`
+  //See tag restrictions here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
+  const componentNameTag = `${componentName.replace(/[^a-zA-Z0-9\+-=\.\_\:\/@]+/g, "")}`
+  const latestVersionTag = `version=${componentNameTag}/latest`
+  const tag = `${componentNameTag}=${version.replace(/\./g, '.')}&${latestVersionTag}`
+  console.log(`Setting tag for ${componentName}: ${tag}`)
   return new Promise((resolve, reject) => {
     var params = {
       localFile: crxFile,
@@ -165,14 +173,20 @@ const uploadExtension = (name, id, version, crxFile) => {
       reject(new Error('Failed to upload extension to S3'))
     })
     uploader.on('end', (params) => {
-      console.log(`Added tags to ${id}/${componentFilename}`)
+      console.log(`Updating tag for ${componentName}: ${componentNameTag}=${getPreviousVersion(version).replace(/\./g, '.')}`)
+      if (version == FirstVersion) {
+        // This is the first version we don't need to update tags for 
+        // the previous version
+        resolve()
+        return
+      }
       var params = {
         Bucket: S3_EXTENSIONS_BUCKET,
         Key: `release/${id}/${previousComponentFilename}`,
         Tagging: {
           TagSet: [
             {
-              Key: `${componentName}`,
+              Key: `${componentNameTag}`,
               Value: `${getPreviousVersion(version).replace(/\./g, '.')}`
             }
           ]


### PR DESCRIPTION
 Fix #129
 
    1. Handle the first version correctly while adding tags
    2. Remove characters restricted in S3 tags. See here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions