### PR TITLE
Fix #132: regex for removing restricted characters for S3 tags

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -152,7 +152,7 @@ const uploadExtension = (name, id, version, crxFile) => {
   const componentName = `${name.replace(/\s/g, '-')}`
   const previousComponentFilename = `extension_${getPreviousVersion(version).replace(/\./g, '_')}.crx`
   //See tag restrictions here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
-  const componentNameTag = `${componentName.replace(/[^a-zA-Z0-9\+-=\.\_\:\/@]+/g, "")}`
+  const componentNameTag = `${componentName.replace(/[^a-zA-Z0-9\+\-=\.\_\:\/@]+/g, "")}`
   const latestVersionTag = `version=${componentNameTag}/latest`
   const tag = `${componentNameTag}=${version.replace(/\./g, '.')}&${latestVersionTag}`
   console.log(`Setting tag for ${componentName}: ${tag}`)

--- a/lib/util.js
+++ b/lib/util.js
@@ -169,6 +169,7 @@ const uploadExtension = (name, id, version, crxFile) => {
     }
     const uploader = client.uploadFile(params)
     uploader.on('error', (err) => {
+      console.error(`Upload failed for ${id}/${componentFilename} with tag ${tag}`)
       console.error('Unable to upload:', err.stack, 'Do you have ~/.aws/credentials filled out?')
       reject(new Error('Failed to upload extension to S3'))
     })
@@ -194,6 +195,7 @@ const uploadExtension = (name, id, version, crxFile) => {
       }
       aws_s3.putObjectTagging(params, function(err, data) {
         if (err) {
+          console.error(`Tagging failed for ${id}/${previousComponentFilename} with tag ${getPreviousVersion(version).replace(/\./g, '.')}`)
           console.error(err, err.stack)
           reject(new Error('Failed to upload extension to S3'))
         }


### PR DESCRIPTION
Fix #132 

## Issue 
`+-=` was interpreted as range `+ to =` which included multiple special characters.