### PR TITLE
Handle errors gracefully for NTP SI/SR jobs

### DIFF
--- a/scripts/generateNTPSponsoredImages.js
+++ b/scripts/generateNTPSponsoredImages.js
@@ -7,6 +7,7 @@ const mkdirp = require('mkdirp')
 const fs = require('fs-extra')
 const request = require('request')
 const commander = require('commander')
+const util = require('../lib/util')
 
 const jsonFileName = 'photo.json'
 const jsonSchemaVersion = 1
@@ -62,8 +63,13 @@ function downloadForRegion (jsonFileUrl, targetResourceDir) {
       if (response && response.statusCode === 200) {
         jsonFileBody = body
       }
-
-      const photoData = JSON.parse(jsonFileBody)
+      let photoData = {}
+      try {
+        photoData = JSON.parse(jsonFileBody)
+      } catch (err) {
+        console.error(`Invalid json file ${jsonFileUrl}`)
+        return reject(error)
+      }
       // Make sure the data has a schema version so that clients can opt to parse or not
       const incomingSchemaVersion = photoData.schemaVersion
       if (!incomingSchemaVersion) {
@@ -122,6 +128,8 @@ async function generateNTPSponsoredImages (dataUrl, targetRegions, excludedTarge
     await downloadForRegion(jsonFileUrl, targetResourceDir)
   }
 }
+
+util.installErrorHandlers()
 
 commander
   .option('-d, --data-url <url>', 'url that refers to data that has ntp sponsored images')

--- a/scripts/generateNTPSuperReferrer.js
+++ b/scripts/generateNTPSuperReferrer.js
@@ -7,6 +7,7 @@ const mkdirp = require('mkdirp')
 const fs = require('fs-extra')
 const request = require('request')
 const commander = require('commander')
+const util = require('../lib/util')
 
 const jsonSchemaVersion = 1
 
@@ -47,7 +48,13 @@ function downloadForRegion (jsonFileUrl, targetResourceDir) {
         jsonFileBody = body
       }
 
-      const data = JSON.parse(jsonFileBody)
+      let data = {}
+      try {
+        data = JSON.parse(jsonFileBody)
+      } catch (err) {
+        console.error(`Invalid json file ${jsonFileUrl}`)
+        return reject(error)
+      }
       // Make sure the data has a schema version so that clients can opt to parse or not
       const incomingSchemaVersion = data.schemaVersion
       if (!incomingSchemaVersion) {
@@ -91,6 +98,8 @@ async function generateNTPSuperReferrer (dataUrl, referrerName) {
   const jsonFileUrl = `${dataUrl}superreferrer/${referrerName}/data.json`
   await downloadForRegion(jsonFileUrl, targetResourceDir)
 }
+
+util.installErrorHandlers()
 
 commander
   .option('-d, --data-url <url>', 'url that refers to data that has ntp super referrer')

--- a/scripts/generateNTPSuperReferrerMappingTable.js
+++ b/scripts/generateNTPSuperReferrerMappingTable.js
@@ -7,6 +7,7 @@ const mkdirp = require('mkdirp')
 const fs = require('fs-extra')
 const request = require('request')
 const commander = require('commander')
+const util = require('../lib/util')
 
 const jsonSchemaVersion = 1
 
@@ -56,6 +57,8 @@ async function generateNTPSuperReferrerMappingTable (dataUrl) {
   const targetFilePath = path.join(rootResourceDir, 'mapping-table.json')
   await downloadMappingTableJsonFile(dataUrl, targetFilePath)
 }
+
+util.installErrorHandlers()
 
 commander
   .option('-d, --data-url <url>', 'url that refers to data that has ntp super referrer')


### PR DESCRIPTION
Returns non-zero when get errors.
Then, jenkins job will not execute next commands.
So far, json syntax error of photo.json/data.json is ignored. (ex, https://ci.brave.com/view/all-extensions/job/brave-core-ext-ntp-sponsored-publish/64/console -> Success reported)

Resolves https://github.com/brave/brave-browser/issues/10689