### PR TITLE
Update adblock-rust to v0.3 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,11 +146,32 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
+    "@types/chrome": {
+      "version": "0.0.100",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.100.tgz",
+      "integrity": "sha512-6wqc/WJyPvS9TrSRcvETIJ02r658weQy2q5CM4wiJRDax5UFcsWXAtZcr0ENSCvcLHrHvYLelYymO8CKxE+iLg==",
+      "requires": {
+        "@types/filesystem": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/filesystem": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.29.tgz",
+      "integrity": "sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==",
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
+      "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM="
     },
     "@types/json-schema": {
       "version": "7.0.5",
@@ -225,8 +246,8 @@
       "dev": true
     },
     "adblock-rust": {
-      "version": "github:brave/adblock-rust#650d472987c173bb638b0d5638895dd175ff1246",
-      "from": "github:brave/adblock-rust#650d472987c173bb638b0d5638895dd175ff1246",
+      "version": "github:brave/adblock-rust#6800c3c7b44f290c80b68c03285b510e0e0389cc",
+      "from": "github:brave/adblock-rust#6800c3c7b44f290c80b68c03285b510e0e0389cc",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -386,6 +407,8 @@
       "from": "github:brave/autoplay-whitelist",
       "requires": {
         "hashset-cpp": "^2.2.1",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.3",
         "node-gyp": "^5.0.3"
       }
     },
@@ -472,7 +495,10 @@
     },
     "brave-site-specific-scripts": {
       "version": "github:brave/brave-site-specific-scripts#f06773084854ab7691dd649b921ed7e75498bfd2",
-      "from": "github:brave/brave-site-specific-scripts"
+      "from": "github:brave/brave-site-specific-scripts",
+      "requires": {
+        "@types/chrome": "0.0.100"
+      }
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -700,7 +726,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1666,6 +1693,7 @@
       "from": "github:brave/extension-whitelist",
       "requires": {
         "hashset-cpp": "^2.2.1",
+        "mkdirp": "^1.0.3",
         "node-gyp": "^5.0.3"
       }
     },
@@ -2185,9 +2213,41 @@
       "version": "github:brave/https-everywhere-builder#b743713ea28651e6b4eeb32bdcaf848b6bf39a1e",
       "from": "github:brave/https-everywhere-builder",
       "requires": {
-        "commander": "^2.11.0",
-        "level": "^5.0.1",
-        "s3-client": "^4.4.2"
+        "aws-sdk": "^2.656.0",
+        "level": "^6.0.1"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.715.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.715.0.tgz",
+          "integrity": "sha512-O6ytb66IXFCowp0Ng2bSPM6v/cZVOhjJWFTR1CG4ieG4IroAaVgB3YQKkfPKA0Cy9B/Ovlsm7B737iuroKsd0w==",
+          "requires": {
+            "buffer": "4.9.2",
+            "events": "1.1.1",
+            "ieee754": "1.1.13",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.3.2",
+            "xml2js": "0.4.19"
+          }
+        },
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "iconv-lite": {
@@ -2971,8 +3031,7 @@
     "mkdirp": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
-      "dev": true
+      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
     },
     "ms": {
       "version": "2.1.2",
@@ -2997,9 +3056,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "neon-cli": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
-    "adblock-rust": "github:brave/adblock-rust#650d472987c173bb638b0d5638895dd175ff1246",
+    "adblock-rust": "github:brave/adblock-rust#6800c3c7b44f290c80b68c03285b510e0e0389cc",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",


### PR DESCRIPTION
This adds support for hosts-based filter list formats, as reported by the default and regional filter list descriptors.