### PR TITLE
Update readme to point to new regional list URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ When developing a new component extension, you must generate a new unique extens
 2. Storing the new PEM in 1Password for Teams
 3. Generating the public key for the `manifest.json` with `openssl rsa -in key.pem -pubout -outform DER | openssl base64 -A`
 4. Generating the component ID with `openssl rsa -in key.pem -pubout -outform DER | shasum -a 256 | head -c32 | tr 0-9a-f a-p`
-5. Updating https://github.com/brave/adblock-rust/blob/master/src/filter_lists/regions.rs with the right component_id and base64_public_key (if this is for AdBlock)
+5. Updating https://github.com/brave/adblock-resources/blob/master/filter_lists/regional.json with the right component_id and base64_public_key (if this is for AdBlock)
 5. Updating the CRX packager to use the new PEM
 
 ## Cloning and Installation


### PR DESCRIPTION
The current URL in the README is broken - regional lists are now stored in the `adblock-resources` repository rather than `adblock-rust`.