### PR TITLE
use v7 HTTPS Everywhere format

### DIFF
--- a/manifests/https-everywhere-updater/default-manifest.json
+++ b/manifests/https-everywhere-updater/default-manifest.json
@@ -1,6 +1,6 @@
 {
   "description": "Brave HTTPS Everywhere Updater extension",
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvn9zSMjTmhkQyrZu5UdN350nPqLoSeCYngcC7yDFwaUHjoBQXCZqGeDC69ciCQ2mlRhcV2nxXqlUDkiC6+7m651nI+gi4oVqHagc7EFUyGA0yuIk7qIMvCBdH7wbET27de0rzbRzRht9EKzEjIhCBtoPnmyrO/8qPrH4XR4cPfnFPuJssBBxC1B35H7rh0Br9qePhPDDe9OjyqYxPuio+YcC9obL4g5krVrfrlKLfFNpIewUcJyBpSlCgfxEyEhgDkK9cILTMUi5vC7GxS3POtZqgfRg8Da4i+NwmjQqrz0JFtPMMSyUnmeMj+mSOL4xZVWr8fU2/GOCXs9gczDpJwIDAQAB",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnlSgb99knPRN5YtflR0xgi6eO3K4XYzF1shgACd40ccwSGyuYwqdBK6f8jAJOL5leBnmvXgHTeiXc1K+l0K8FgQMO9Y1EtzBHfdXxN3u7NKoQmCO9m5dlz771m4Qgg+JtB6hsmqNAMkqee50wQn3q8+tcS8xM63zOGM0E9ub/tFAxPTAfLJlka2Qn0iFj7ON2OzfpJNQguPx4rJS34ziBfXagFF+tlNzdy0BOHIHOiqtZ09sOgHaptIZdWVef6Y9v4fjOlVNlrn45rt98whrYFAgbOutakZNf6PEQ/brga6zAhu6B/0kIOEFZhDC198gqqaAacV8bHmryUxjWPEiqwIDAQAB",
   "manifest_version": 2,
   "name": "Brave HTTPS Everywhere Updater",
   "version": "0.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,17 +2210,16 @@
       }
     },
     "https-everywhere-builder": {
-      "version": "github:brave/https-everywhere-builder#b743713ea28651e6b4eeb32bdcaf848b6bf39a1e",
-      "from": "github:brave/https-everywhere-builder",
+      "version": "github:brave/https-everywhere-builder#6a4ab3f4a14f2ef8791df89f4860666d0d508ebd",
+      "from": "github:brave/https-everywhere-builder#httpse-rust",
       "requires": {
-        "aws-sdk": "^2.656.0",
-        "level": "^6.0.1"
+        "aws-sdk": "^2.656.0"
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.715.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.715.0.tgz",
-          "integrity": "sha512-O6ytb66IXFCowp0Ng2bSPM6v/cZVOhjJWFTR1CG4ieG4IroAaVgB3YQKkfPKA0Cy9B/Ovlsm7B737iuroKsd0w==",
+          "version": "2.746.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.746.0.tgz",
+          "integrity": "sha512-TMa/jxS2AHuZqAYNyv0X+Ltjt2NebjraT7xdL6NqKUiu0U61j0uav+gr2zw9lkz5q+KeTeYo7pg+S9LXVawHXw==",
           "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
     "ethereum-remote-client": "^0.1.74",
     "extension-whitelist": "github:brave/extension-whitelist",
-    "https-everywhere-builder": "brave/https-everywhere-builder",
+    "https-everywhere-builder": "github:brave/https-everywhere-builder#httpse-rust",
     "recursive-readdir-sync": "^1.0.6",
     "referrer-whitelist": "github:brave/referrer-whitelist",
     "request": "^2.88.0",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -81,7 +81,7 @@ const getDATFileVersionByComponentType = (componentType) => {
     case 'ad-block-updater':
       return ''
     case 'https-everywhere-updater':
-      return '6.0'
+      return '7.0'
     case 'local-data-files-updater':
       return '1'
     case 'speedreader-updater':
@@ -136,7 +136,7 @@ const getManifestsDirByComponentType = (componentType) => {
 
 const getNormalizedDATFileName = (datFileName) =>
   datFileName === 'ABPFilterParserData' ||
-  datFileName === 'httpse.leveldb' ||
+  datFileName === 'httpse-rs.json' ||
   datFileName === 'ReferrerWhitelist' ||
   datFileName === 'ExtensionWhitelist' ||
   datFileName === 'Greaselion' ||
@@ -165,7 +165,7 @@ const getDATFileListByComponentType = (componentType) => {
           return acc
         }, [])
     case 'https-everywhere-updater':
-      return path.join('node_modules', 'https-everywhere-builder', 'out', 'httpse.leveldb.zip').split()
+      return path.join('node_modules', 'https-everywhere-builder', 'out', 'httpse-rs.json.zip').split()
     case 'local-data-files-updater':
       return [path.join('node_modules', 'autoplay-whitelist', 'data', 'AutoplayWhitelist.dat'),
         path.join('node_modules', 'extension-whitelist', 'data', 'ExtensionWhitelist.dat'),


### PR DESCRIPTION
Part of the work required for https://github.com/brave/brave-browser/issues/5280.

This PR uses the updated `https-everywhere-builder` dependency from https://github.com/brave/https-everywhere-builder/pull/40, in order to package it for use with Brave versions incorporating https://github.com/brave/brave-core/pull/6520.

I have already generated a base64 public key, component id, and private key according to the instructions on the README, but I haven't been able to upload the private key anywhere - happy to update these PRs to use an "official" one if necessary, or upload this one myself given adequate permissions.