### PR TITLE
Fix #169: Skip tagging if the previous component does not exist

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -201,35 +201,40 @@ const uploadExtension = (name, id, version, crxFile) => {
         // Proceed to update tag for previous version to remove its latest
         // release version tag.
         console.log(`Updating tag for ${componentName}: ${componentNameTag} = ${getPreviousVersion(version).replace(/\./g, '.')}`)
-        if (version == FirstVersion) {
-          // This is the first version we don't need to update tags for
-          // the previous version
-          console.log(`No need to update previous version tag for ${componentName} because it is the first version.`)
-          resolve()
-          return
-        }
 
         var params = {
           Bucket: S3_EXTENSIONS_BUCKET,
-          Key: `release/${id}/${previousComponentFilename}`,
-          Tagging: {
-            TagSet: [
-              {
-                Key: `${componentNameTag}`,
-                Value: `${getPreviousVersion(version).replace(/\./g, '.')}`
-              }
-            ]
-          }
+          Key: `release/${id}/${previousComponentFilename}`
         }
-        aws_s3.putObjectTagging(params, function(err, data) {
-          if (err) {
-            console.error(`Tagging failed for ${id}/${previousComponentFilename} with tag ${getPreviousVersion(version).replace(/\./g, '.')}`)
-            console.error(err, err.stack)
-            reject(new Error('Failed to upload extension to S3'))
+
+        aws_s3.headObject(params, function (err, metadata) {
+          if (err && err.code === 'NotFound') {
+            //No need to update tags if the file doesn't exist
+            resolve()
+          } else {
+            var params = {
+              Bucket: S3_EXTENSIONS_BUCKET,
+              Key: `release/${id}/${previousComponentFilename}`,
+              Tagging: {
+                TagSet: [
+                  {
+                    Key: `${componentNameTag}`,
+                    Value: `${getPreviousVersion(version).replace(/\./g, '.')}`
+                  }
+                ]
+              }
+            }
+            aws_s3.putObjectTagging(params, function(err, data) {
+              if (err) {
+                console.error(`Tagging failed for ${id}/${previousComponentFilename} with tag ${getPreviousVersion(version).replace(/\./g, '.')}`)
+                console.error(err, err.stack)
+                reject(new Error('Failed to upload extension to S3'))
+              }
+              console.log(`Updated tags for ${id}/${previousComponentFilename}`)
+              resolve()
+            })
           }
-          console.log(`Updated tags for ${id}/${previousComponentFilename}`)
-          resolve()
-        })
+        });
       })
     })
   })


### PR DESCRIPTION
Fix #169 