### PR TITLE
Remove last use of adblock-rust's list API

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -11,6 +11,32 @@ const uBlockScriptlets = path.join(uBlockLocalRoot, 'assets/resources/scriptlets
 
 const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/dist/resources.json'
 
+const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
+const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
+
+/**
+ * Returns a promise that which resolves with the body parsed as JSON
+ *
+ * @param url The URL to fetch from
+ * @return a promise that resolves with the content of the list or rejects with an error message.
+ */
+const requestJSON = (url) => new Promise((resolve, reject) => {
+  request.get(url, function (error, response, body) {
+    if (error) {
+      reject(new Error(`Request error: ${error}`))
+      return
+    }
+    if (response.statusCode !== 200) {
+      reject(new Error(`Error status code ${response.statusCode} returned for URL: ${url}`))
+      return
+    }
+    resolve(JSON.parse(body))
+  })
+})
+
+const getDefaultLists = requestJSON.bind(null, defaultListsUrl)
+const getRegionalLists = requestJSON.bind(null, regionalListsUrl)
+
 /**
  * Returns a promise that generates a resources file from the uBlock Origin
  * repo hosted on GitHub
@@ -38,3 +64,5 @@ const generateResourcesFile = (outLocation) => {
 }
 
 module.exports.generateResourcesFile = generateResourcesFile
+module.exports.getDefaultLists = getDefaultLists
+module.exports.getRegionalLists = getRegionalLists

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -3,36 +3,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { Engine, FilterFormat, FilterSet } = require('adblock-rust')
-const { generateResourcesFile } = require('../lib/adBlockRustUtils')
+const { generateResourcesFile, getDefaultLists, getRegionalLists } = require('../lib/adBlockRustUtils')
 const path = require('path')
 const fs = require('fs')
 const request = require('request')
-
-const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
-const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
-
-/**
- * Returns a promise that which resolves with the body parsed as JSON
- *
- * @param url The URL to fetch from
- * @return a promise that resolves with the content of the list or rejects with an error message.
- */
-const requestJSON = (url) => new Promise((resolve, reject) => {
-  request.get(url, function (error, response, body) {
-    if (error) {
-      reject(new Error(`Request error: ${error}`))
-      return
-    }
-    if (response.statusCode !== 200) {
-      reject(new Error(`Error status code ${response.statusCode} returned for URL: ${url}`))
-      return
-    }
-    resolve(JSON.parse(body))
-  })
-})
-
-const getDefaultLists = requestJSON.bind(null, defaultListsUrl)
-const getRegionalLists = requestJSON.bind(null, regionalListsUrl)
 
 /**
  * Returns a promise that which resolves with the list data

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { lists } = require('adblock-rust')
 const fs = require('fs-extra')
 const mkdirp = require('mkdirp')
 const path = require('path')
+
+const { getRegionalLists } = require('../lib/adBlockRustUtils')
 
 var outPath = path.join('build', 'ad-block-updater');
 
@@ -38,9 +39,10 @@ const generateManifestFileForDefaultAdblock =
 
 const generateManifestFilesForAllRegions = () => {
   let p = Promise.resolve()
-  new lists('regions').forEach((region) => { // eslint-disable-line
-    p = p.then(generateManifestFile.bind(null, region.title,
-      region.base64_public_key, region.uuid))
+  getRegionalLists().then(regions => {
+    regions.forEach((region) => {
+      p = p.then(generateManifestFile.bind(null, region.title, region.base64_public_key, region.uuid))
+    })
   })
 }
 


### PR DESCRIPTION
Follow up from #125; I hadn't realized we used the `lists` method separately in another location to generate adblock manifest files. I've abstracted the newer behavior out into `lib/adBlockRustUtils.js` so that the same logic can be used both there and in the DAT file creation step.