### PR TITLE
Include messages localizations file in DAT file normalization list

### DIFF
--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -148,6 +148,7 @@ const getNormalizedDATFileName = (datFileName) =>
   datFileName === 'ReferrerWhitelist' ||
   datFileName === 'ExtensionWhitelist' ||
   datFileName === 'Greaselion' ||
+  datFileName === 'messages' ||
   datFileName === 'AutoplayWhitelist' || 
   datFileName === 'speedreader-updater' || 
   datFileName === 'content-stylesheet' ||


### PR DESCRIPTION
Now that we include localizations with Greaselion scripts, we need to update `getNormalizedDATFileName` to use the default manifest for `messages.json` files. Without this fix, we're receiving the following error when attempting to deploy a new Greaselion script:

```
14:58:08  Unhandled rejection: Error: ENOENT: no such file or directory, open 'manifests/local-data-files-updater/messages-manifest.json'
14:58:08      at Object.openSync (fs.js:447:3)
14:58:08      at Object.readFileSync (fs.js:349:35)
14:58:08      at Object.parseManifest (/Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish/lib/util.js:79:19)
14:58:08      at processDATFile (/Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish/scripts/packageComponent.js:199:31)
14:58:08      at Array.forEach (<anonymous>)
14:58:08      at /Users/jenkins/jenkins/workspace/brave-core-ext-local-data-files-update-publish/scripts/packageComponent.js:241:6
14:58:08      at processTicksAndRejections (internal/process/task_queues.js:89:5) {
14:58:08    errno: -2,
14:58:08    syscall: 'open',
14:58:08    code: 'ENOENT',
14:58:08    path: 'manifests/local-data-files-updater/messages-manifest.json'
14:58:08  }
14:58:08  npm ERR! code ELIFECYCLE
14:58:08  npm ERR! errno 1
14:58:08  npm ERR! brave-core-crx-packager@1.0.0 package-local-data-files: `node ./scripts/packageComponent --type local-data-files-updater "--binary" "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome" "--keys-directory" "****"`
14:58:08  npm ERR! Exit status 1
14:58:08  npm ERR! 
14:58:08  npm ERR! Failed at the brave-core-crx-packager@1.0.0 package-local-data-files script.
14:58:08  npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
14:58:08  
14:58:08  npm ERR! A complete log of this run can be found in:
14:58:08  npm ERR!     /Users/jenkins/.npm/_logs/2020-10-13T18_58_06_563Z-debug.log
```