### PR TITLE
Bump ethereum-remote-client to 0.1.79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1669,9 +1669,9 @@
       "dev": true
     },
     "ethereum-remote-client": {
-      "version": "0.1.77",
-      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.77.tgz",
-      "integrity": "sha512-dd4YoOicuFvxTuLgVpQtdh9Lu1I5j4xkGzZBTrnfW9gbr58Vdfs6s2qMqI0RlyjxYyaQ3xW0piStoZZqhbBa+w=="
+      "version": "0.1.79",
+      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.79.tgz",
+      "integrity": "sha512-7J3XCzLZfLDfazPnzqn/Zz+iSonCBjTE4MSGVXfWm2CZC7mjPsPZ5xbwspLdWx3YPjUcJvDaQeTKDfOrJQQ2mg=="
     },
     "events": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,6 +228,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
       "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+      "dev": true,
       "requires": {
         "level-concat-iterator": "~2.0.0",
         "xtend": "~4.0.0"
@@ -2217,6 +2218,29 @@
         "level": "^6.0.1"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            }
+          }
+        },
         "aws-sdk": {
           "version": "2.715.0",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.715.0.tgz",
@@ -2241,6 +2265,38 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
             "isarray": "^1.0.0"
+          }
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            }
           }
         },
         "uuid": {
@@ -2732,6 +2788,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
       "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
+      "dev": true,
       "requires": {
         "level-js": "^4.0.0",
         "level-packager": "^5.0.0",
@@ -2783,6 +2840,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz",
       "integrity": "sha512-PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==",
+      "dev": true,
       "requires": {
         "abstract-leveldown": "~6.0.1",
         "immediate": "~3.2.3",
@@ -3432,7 +3490,8 @@
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
     },
     "opener": {
       "version": "1.5.1",
@@ -6109,6 +6168,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "ethereum-remote-client": "^0.1.77",
+    "ethereum-remote-client": "^0.1.79",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "brave/https-everywhere-builder",
     "recursive-readdir-sync": "^1.0.6",


### PR DESCRIPTION
There were some additional changes added by an upstream dependency in the package lock file, I tried to keep the commits clean to make that obvious.