### PR TITLE
Support building on node v12+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -404,10 +404,10 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "autoplay-whitelist": {
-      "version": "github:brave/autoplay-whitelist#30de0adc20f5c7bb1cad23f17ca9599f8a193db9",
+      "version": "github:brave/autoplay-whitelist#f4ffd297c2df5a15e401ce8686e65dea1466986c",
       "from": "github:brave/autoplay-whitelist",
       "requires": {
-        "hashset-cpp": "^2.2.1",
+        "hashset-cpp": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
         "minimist": "^1.2.5",
         "mkdirp": "^1.0.3",
         "node-gyp": "^5.0.3"
@@ -1690,10 +1690,10 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extension-whitelist": {
-      "version": "github:brave/extension-whitelist#7843f62e26a23c51336330e220e9d7992680aae9",
+      "version": "github:brave/extension-whitelist#001729576f70f4da47a6a181cedb4993ce583fb8",
       "from": "github:brave/extension-whitelist",
       "requires": {
-        "hashset-cpp": "^2.2.1",
+        "hashset-cpp": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
         "mkdirp": "^1.0.3",
         "node-gyp": "^5.0.3"
       }
@@ -2184,9 +2184,8 @@
       }
     },
     "hashset-cpp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.2.1.tgz",
-      "integrity": "sha512-pO16ApkT0SEtXmCy9FgcwwPnTUbdRzL000gcpOtJyIY3OOSYvh4eQaZdYjlU+Y1AOzy3am6msgHZZ5Yok19aLw=="
+      "version": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
+      "from": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f"
     },
     "hosted-git-info": {
       "version": "2.8.8",


### PR DESCRIPTION
Pulls in updates from `autoplay-whitelist` and `extension-whitelist` to support building on more recent Node versions, including the current v15.6.x.