### PR TITLE
Update adblock-rust to support full-regex-handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,8 +247,8 @@
       "dev": true
     },
     "adblock-rust": {
-      "version": "github:brave/adblock-rust#8952994b01fadb493e272f570a7fb4e72c3faf1e",
-      "from": "github:brave/adblock-rust#8952994b01fadb493e272f570a7fb4e72c3faf1e",
+      "version": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
+      "from": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
       "requires": {
         "neon-cli": "0.4.0"
       }
@@ -2124,9 +2124,9 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -6302,9 +6302,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
       "optional": true
     },
     "unicode-length": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
-    "adblock-rust": "github:brave/adblock-rust#8952994b01fadb493e272f570a7fb4e72c3faf1e",
+    "adblock-rust": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",


### PR DESCRIPTION
For whatever reason, the npm version of adblock-rust has been compiled without support for regex rules. They are enabled in-browser, but the rulesets served from here are built using the npm version, and so we are running into issues like https://github.com/brave/brave-browser/issues/14140. I've updated the dependency here to include https://github.com/brave/adblock-rust/commit/07f22810f1332895abb71286763a10bb2b555bdd, which should solve this problem.