### PR TITLE
Fixed failure when photo.json is empty object

### DIFF
--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -9,15 +9,17 @@ const util = require('../lib/util')
 const request = require('request')
 
 const jsonSchemaVersion = 1
+const fallbackSchemaVersion = 1
 
 const createPhotoJsonFile = (path, body) => {
   fs.writeFileSync(path, body)
 }
 
 const getImageFileNameListFrom = (photoJsonObj) => {
-  let fileList = []
-  if (photoJsonObj.logo)
+  const fileList = []
+  if (photoJsonObj.logo) {
     fileList.push(photoJsonObj.logo.imageUrl)
+  }
 
   if (photoJsonObj.wallpapers) {
     photoJsonObj.wallpapers.forEach((wallpaper) => {
@@ -61,7 +63,7 @@ const generatePublicKeyAndID = (privateKeyFile) => {
 }
 
 const isValidSchemaVersion = (version) => {
-  return version === jsonSchemaVersion;
+  return [jsonSchemaVersion].includes(version)
 }
 
 const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
@@ -87,15 +89,11 @@ const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
         return reject(error)
       }
       console.log(`Done - json file ${jsonFileUrl} parsing`)
+
       // Make sure the data has a schema version so that clients can opt to parse or not
-      let incomingSchemaVersion = photoData.schemaVersion
+      const incomingSchemaVersion = photoData.schemaVersion || fallbackSchemaVersion
       console.log(`Schema version: ${incomingSchemaVersion} from ${jsonFileUrl}`)
-      if (!incomingSchemaVersion) {
-        // Source has no schema version, assume and set current version.
-        // TODO(petemill): Don't allow this once the source is established to always
-        // have a schema version.
-        incomingSchemaVersion = jsonSchemaVersion
-      } else if (!isValidSchemaVersion(incomingSchemaVersion)) {
+      if (!isValidSchemaVersion(incomingSchemaVersion)) {
         console.error(`Error: Cannot parse JSON data at ${jsonFileUrl} since it has a schema version of ${incomingSchemaVersion} but we expected ${jsonSchemaVersion}! This region will not be updated.`)
         return reject(error)
       }

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -88,7 +88,7 @@ const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
       }
       console.log(`Done - json file ${jsonFileUrl} parsing`)
       // Make sure the data has a schema version so that clients can opt to parse or not
-      const incomingSchemaVersion = photoData.schemaVersion
+      let incomingSchemaVersion = photoData.schemaVersion
       console.log(`Schema version: ${incomingSchemaVersion} from ${jsonFileUrl}`)
       if (!incomingSchemaVersion) {
         // Source has no schema version, assume and set current version.


### PR DESCRIPTION
Fixed assigning to const var schemaVersion.
Found this issue while testing https://github.com/brave-experiments/ntp-si-assets/pull/256