### PR TITLE
Update adblock-rust to 0.3.7

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -1,4 +1,4 @@
-const { uBlockResources } = require('adblock-rust')
+const { uBlockResources } = require('adblock-rs')
 
 const path = require('path')
 const fs = require('fs')

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,10 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
-    "adblock-rust": {
-      "version": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
-      "from": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
+    "adblock-rs": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.7.tgz",
+      "integrity": "sha512-BHbIKexaYoZ/xZIG8a4kFg902Wct4hDq/GDoIz7AZwBNesi6Osh7fPLAm2bHpPRFwtzHiaX64+tIQ6z07jdkWQ==",
       "requires": {
         "neon-cli": "0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
-    "adblock-rust": "github:brave/adblock-rust#07f22810f1332895abb71286763a10bb2b555bdd",
+    "adblock-rs": "0.3.7",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { Engine, FilterFormat, FilterSet } = require('adblock-rust')
+const { Engine, FilterFormat, FilterSet } = require('adblock-rs')
 const { generateResourcesFile, getDefaultLists, getRegionalLists } = require('../lib/adBlockRustUtils')
 const path = require('path')
 const fs = require('fs')


### PR DESCRIPTION
This version adds support for `$document` filter rules in the generated DAT files.