### PR TITLE
Update packageNTPBackgroundImagesComponent.js

### DIFF
--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -54,7 +54,6 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
   mkdirp.sync(stagingDir)
   mkdirp.sync(crxOutputDir)
  util.getNextVersion(endpoint, region, componentID).then((version) => {
-    version = '1.0.0'
     const crxFile = path.join(crxOutputDir, `ntp-background-images.crx`)
     stageFiles(version, stagingDir)
     util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)


### PR DESCRIPTION
Fixed NTP BI component version is always `1.0.0`
version should be the value received from updater.