### PR TITLE
[wip] Change resources URL to fetch from to be LFS variety

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -9,7 +9,7 @@ const uBlockWebAccessibleResources = path.join(uBlockLocalRoot, 'src/web_accessi
 const uBlockRedirectEngine = path.join(uBlockLocalRoot, 'src/js/redirect-engine.js')
 const uBlockScriptlets = path.join(uBlockLocalRoot, 'assets/resources/scriptlets.js')
 
-const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/dist/resources.json'
+const braveResourcesUrl = 'https://github.com/brave/adblock-resources/blob/master/dist/resources.json?raw=true'
 
 const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
 const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'


### PR DESCRIPTION
This PR should be merged after https://github.com/brave/adblock-resources/pull/30 (double-check what the resources LFS URL is)