### PR TITLE
Update ipfs node to 0.10.0

### DIFF
--- a/scripts/downloadIpfsDaemon.js
+++ b/scripts/downloadIpfsDaemon.js
@@ -8,56 +8,7 @@ const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const util = require('../lib/util')
-const ipfsVersion = '0.9.1'
-const fsRepoVersion = '1.0.0'
-
-// Downloads the current (platform-specific) fs-repo-migration component
-const downloadFsRepoMigration = (platform) => {
-  if (platform !== 'darwin')
-      return
-  const repoPath = path.join('build', 'ipfs-daemon-updater', 'downloads')
-
-  const ipfsDistPrefix = `https://cloudflare-ipfs.com/ipns/dist.ipfs.io/fs-repo-10-to-11/v${fsRepoVersion}/`
-
-  const zipSuffix = '.tar.gz'
-
-  const repoFilename = `fs-repo-10-to-11_v${fsRepoVersion}_${platform}-amd64`
-  const targetFilename = `fs-repo-10-to-11`
-  const ipfsURL = ipfsDistPrefix + repoFilename + zipSuffix
-
-  let sha512IPFS = ''
-
-  switch (platform) {
-    case 'darwin':
-      sha512IPFS = '9a8b8b18c7757e5f2a0abd62dc33fc14616195b27776a967d4adff361a2becedebf286eee156af05bdbf1f39b0da5cc33264939a695a7866abe50a06b817d5cd'
-      break
-    default:
-      throw new Error('fs-repo migration tool download failed; unrecognized platform: ' + platform)
-  }
-
-  mkdirp.sync(repoPath)
-
-  const repoTool = path.join(repoPath, targetFilename)
-  const decompress = `bsdtar xf - -C ${repoPath}`
-  const move = `mv ${path.join(repoPath, 'fs-repo-10-to-11')} ${path.join(repoPath, 'tmp')}`
-  const copy = `cp ${path.join(repoPath, 'tmp', 'fs-repo-10-to-11')} ${repoTool}`
-  const rm = `rm -r ${path.join(repoPath, 'tmp')}`
-  const cmd = `curl -s ${ipfsURL} | ${decompress} && ${move} && ${copy} && ${rm}`
-  console.log(cmd)
-  // Download and decompress the client
-  execSync(cmd)
-
-  // Verify the checksum
-  if (!verifyChecksum(repoTool, sha512IPFS)) {
-    console.error('FsRepoMigration tool checksum verification failed')
-    process.exit(1)
-  }
-
-  // Make it executable
-  fs.chmodSync(repoTool, 0o755)
-
-  return repoTool
-}
+const ipfsVersion = '0.9.0'
 
 // Downloads the current (platform-specific) Ipfs Daemon from ipfs.io
 const downloadIpfsDaemon = (platform) => {
@@ -119,7 +70,6 @@ const verifyChecksum = (file, hash) => {
 util.installErrorHandlers()
 
 downloadIpfsDaemon('darwin')
-downloadFsRepoMigration('darwin')
 downloadIpfsDaemon('linux')
 downloadIpfsDaemon('win32')
 

--- a/scripts/downloadIpfsDaemon.js
+++ b/scripts/downloadIpfsDaemon.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const util = require('../lib/util')
-const ipfsVersion = '0.9.0'
+const ipfsVersion = '0.10.0'
 
 // Downloads the current (platform-specific) Ipfs Daemon from ipfs.io
 const downloadIpfsDaemon = (platform) => {
@@ -26,13 +26,13 @@ const downloadIpfsDaemon = (platform) => {
 
   switch (platform) {
     case 'darwin':
-      sha512IPFS = '7957a7838f2a19043af149be6df63a1181d80868d1ee10b44527fc93e42ced41d82a765bc435d3c34d52508584999d3ec274a4006c35e2c633b04b8ea7403ed0'
+      sha512IPFS = '5a010789a0b91c859fd131abb51118b5ff1fe865ebee9ba3bc9283685abbc673f0a95ea4113a4bb16c6c4b4627bbae062d0a1fc00d2c1f82371913e9dc43a8a7'
       break
     case 'linux':
-      sha512IPFS = 'bae5e2286e6921614282f12ba4c70c5e0ddbc2e613e5e3e66ab0fd1f316f1ca37984d1520b923cea1a678ba25001ffeeb7fe615a6333b6a71ac6473822c1e6e2'
+      sha512IPFS = 'bb0fe78a3142489fd6b7f608053b2e20cd9a4788febbeb4a0413783ac00306842451678f0953a917c459dfa69e4308f381ca0b6385f221dd70f7e01190bce2d1'
       break
     case 'win32':
-      sha512IPFS = '2dbbd3d249bd890f26732f1409abf12c5686d0d810c77599bc936fd7b23b49de370d293e482f47ae3084c5be39a250216df3a1f43d150fc9eb20b4dae0061c5d'
+      sha512IPFS = '7b0c17696330652af1c8709aaea8bee460e51cd3091e8128e4603b6f5c5d774344500e139f0aba1e98e7cabe6ee56f2b2958bad5dea1df7e773d747fbec9058b'
       break
     default:
       throw new Error('Ipfs Daemon download failed; unrecognized platform: ' + platform)

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -20,12 +20,6 @@ const getIpfsDaemonPath = (platform) => {
   return path.join(ipfsPath, ipfsFilename)
 }
 
-const getFsToolPath = () => {
-  const ipfsPath = path.join('build', 'ipfs-daemon-updater', 'downloads')
-  const toolFilename = `fs-repo-10-to-11`
-  return path.join(ipfsPath, toolFilename)
-}
-
 const getOriginalManifest = (platform) => {
   return path.join('manifests', 'ipfs-daemon-updater', `ipfs-daemon-updater-${platform}-manifest.json`)
 }
@@ -38,17 +32,16 @@ const packageIpfsDaemon = (binary, endpoint, region, platform, key) => {
   util.getNextVersion(endpoint, region, id).then((version) => {
     const stagingDir = path.join('build', 'ipfs-daemon-updater', platform)
     const ipfsDaemon = getIpfsDaemonPath(platform)
-    const fsRepoTool = (platform === 'darwin') ? getFsToolPath() : ''
     const crxOutputDir = path.join('build', 'ipfs-daemon-updater')
     const crxFile = path.join(crxOutputDir, `ipfs-daemon-updater-${platform}.crx`)
     const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `ipfs-daemon-updater-${platform}.pem`)
-    stageFiles(platform, ipfsDaemon, fsRepoTool, version, stagingDir)
+    stageFiles(platform, ipfsDaemon, version, stagingDir)
     util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
 
-const stageFiles = (platform, ipfsDaemon, fsRepoTool, version, outputDir) => {
+const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
   const originalManifest = getOriginalManifest(platform)
   const outputManifest = path.join(outputDir, 'manifest.json')
   const outputIpfsClient = path.join(outputDir, path.parse(ipfsDaemon).base)
@@ -63,10 +56,6 @@ const stageFiles = (platform, ipfsDaemon, fsRepoTool, version, outputDir) => {
 
   fs.copyFileSync(originalManifest, outputManifest)
   fs.copyFileSync(ipfsDaemon, outputIpfsClient)
-  if (platform === 'darwin' && fsRepoTool) {
-    const outputFsRepoTool = path.join(outputDir, path.parse(fsRepoTool).base)
-    fs.copyFileSync(fsRepoTool, outputFsRepoTool)
-  }
 
   replace.sync(replaceOptions)
 }

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -11,7 +11,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const replace = require('replace-in-file')
 const util = require('../lib/util')
-const ipfsVersion = '0.9.1'
+const ipfsVersion = '0.10.0'
 
 const getIpfsDaemonPath = (platform) => {
   const ipfsPath = path.join('build', 'ipfs-daemon-updater', 'downloads')


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/17934

Revert fs-repo-10-to-11 migration node update because 0.10 handles it natively
Add update to 0.10.0-rc2