### PR TITLE
Update adblock-rust to v0.3.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,17 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "brave-core-crx-packager",
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "adblock-rs": "^0.3.13",
+        "@metamask/contract-metadata": "git+https://github.com/MetaMask/contract-metadata.git",
+        "adblock-rs": "^0.3.17",
         "ajv": "^6.10.0",
         "autoplay-whitelist": "github:brave/autoplay-whitelist",
         "aws-sdk": "^2.449.0",
         "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-        "ethereum-remote-client": "^0.1.90",
+        "ethereum-remote-client": "^0.1.104",
         "extension-whitelist": "github:brave/extension-whitelist",
         "https-everywhere-builder": "brave/https-everywhere-builder",
         "recursive-readdir-sync": "^1.0.6",
@@ -181,6 +183,14 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "node_modules/@metamask/contract-metadata": {
+      "version": "1.29.0",
+      "resolved": "git+ssh://git@github.com/MetaMask/contract-metadata.git#13fdcac64a541e5ee0351970618802c16c193433",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -275,12 +285,12 @@
       "dev": true
     },
     "node_modules/adblock-rs": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.13.tgz",
-      "integrity": "sha512-+HgqGy0jE6g2A+2Ffks8S6q/1ZKpIdPjLu5DvleKYSZ7IhjbimIJK6II94GMKzfdKYNla+GkrCPHIbbB7ASn4g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.17.tgz",
+      "integrity": "sha512-WlsuJyCCekZC7zHXksksBTnzfNYXYIeSyzbqWl/0yqmyEjppJG3GoKMdA7hk4fz8MYX/XLqMGAhLdYAF5bAmzQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "neon-cli": "0.8.2"
+        "neon-cli": "0.8.3"
       }
     },
     "node_modules/ajv": {
@@ -801,11 +811,11 @@
       }
     },
     "node_modules/command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
       "dependencies": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
@@ -1732,13 +1742,9 @@
       }
     },
     "node_modules/ethereum-remote-client": {
-      "version": "0.1.90",
-      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.90.tgz",
-      "integrity": "sha512-J0oWJ3hrZaNcSz8knAy7x+CYKkHhNvbychXRA3KtTEWpe8nWV31isAOE64mYgfn0IbDPAY4Lp0XEtYv66b+3kg==",
-      "engines": {
-        "node": "^10.16.0",
-        "yarn": "^1.16.0"
-      }
+      "version": "0.1.104",
+      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.104.tgz",
+      "integrity": "sha512-qM/T6aZb+Cq0xR0UM6jYVCsmSHJkjhxorKCrxb/apD38g6+lD7Mc5tmQN/0YY6QR7KgcNlfJYogejU9GMKwj7w=="
     },
     "node_modules/events": {
       "version": "1.1.1",
@@ -3485,9 +3491,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/neon-cli": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.8.2.tgz",
-      "integrity": "sha512-vYRBmiLiwPVeBvR9huCFXRAtdLYfsoSG3hgsXrcuyMSXk7yqpnZlgvOGGuxfhrRb/iNfcd0M0cEs0j22mDgZ+A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.8.3.tgz",
+      "integrity": "sha512-I44MB8PD0AEyFr/b5icR4sX1tsjdkb2T2uWEStG4Uf5C/jzalZPn7eazbQrW6KDyXNd8bc+LVuOr1v6CGTa1KQ==",
       "dependencies": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -3526,9 +3532,9 @@
       }
     },
     "node_modules/neon-cli/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7705,9 +7711,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -8344,6 +8350,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@metamask/contract-metadata": {
+      "version": "git+ssh://git@github.com/MetaMask/contract-metadata.git#13fdcac64a541e5ee0351970618802c16c193433",
+      "from": "@metamask/contract-metadata@git+https://github.com/MetaMask/contract-metadata.git"
+    },
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -8428,11 +8438,11 @@
       "dev": true
     },
     "adblock-rs": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.13.tgz",
-      "integrity": "sha512-+HgqGy0jE6g2A+2Ffks8S6q/1ZKpIdPjLu5DvleKYSZ7IhjbimIJK6II94GMKzfdKYNla+GkrCPHIbbB7ASn4g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.3.17.tgz",
+      "integrity": "sha512-WlsuJyCCekZC7zHXksksBTnzfNYXYIeSyzbqWl/0yqmyEjppJG3GoKMdA7hk4fz8MYX/XLqMGAhLdYAF5bAmzQ==",
       "requires": {
-        "neon-cli": "0.8.2"
+        "neon-cli": "0.8.3"
       }
     },
     "ajv": {
@@ -8867,11 +8877,11 @@
       }
     },
     "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
       "requires": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
@@ -9641,9 +9651,9 @@
       "dev": true
     },
     "ethereum-remote-client": {
-      "version": "0.1.90",
-      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.90.tgz",
-      "integrity": "sha512-J0oWJ3hrZaNcSz8knAy7x+CYKkHhNvbychXRA3KtTEWpe8nWV31isAOE64mYgfn0IbDPAY4Lp0XEtYv66b+3kg=="
+      "version": "0.1.104",
+      "resolved": "https://registry.npmjs.org/ethereum-remote-client/-/ethereum-remote-client-0.1.104.tgz",
+      "integrity": "sha512-qM/T6aZb+Cq0xR0UM6jYVCsmSHJkjhxorKCrxb/apD38g6+lD7Mc5tmQN/0YY6QR7KgcNlfJYogejU9GMKwj7w=="
     },
     "events": {
       "version": "1.1.1",
@@ -11055,9 +11065,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "neon-cli": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.8.2.tgz",
-      "integrity": "sha512-vYRBmiLiwPVeBvR9huCFXRAtdLYfsoSG3hgsXrcuyMSXk7yqpnZlgvOGGuxfhrRb/iNfcd0M0cEs0j22mDgZ+A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.8.3.tgz",
+      "integrity": "sha512-I44MB8PD0AEyFr/b5icR4sX1tsjdkb2T2uWEStG4Uf5C/jzalZPn7eazbQrW6KDyXNd8bc+LVuOr1v6CGTa1KQ==",
       "requires": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -11084,9 +11094,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -14220,9 +14230,9 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uglify-js": {
-      "version": "3.13.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
-      "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
       "optional": true
     },
     "unicode-length": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://github.com/MetaMask/contract-metadata.git",
-    "adblock-rs": "^0.3.13",
+    "adblock-rs": "^0.3.17",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.449.0",

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -79,7 +79,7 @@ const generateDataFileFromLists = (filterRuleData, outputDATFilename, outSubdir)
     filterSet.addFilters(data.split('\n'), format)
   }
   const client = new Engine(filterSet, true)
-  const arrayBuffer = client.serialize()
+  const arrayBuffer = client.serializeCompressed()
   const outPath = getOutPath(outputDATFilename, outSubdir)
   fs.writeFileSync(outPath, Buffer.from(arrayBuffer))
 }


### PR DESCRIPTION
This includes a small tweak to where `$redirect` rules are stored in the serialization format. The goal is to support a future change to the in-browser matching algorithm such that the newer `$redirect-rule` option can also work. Existing clients should not experience any differences in matching behavior as a result of this change.

More details available at https://github.com/brave/adblock-rust/issues/169#issuecomment-916471765.