### PR TITLE
add debounce configuration to local data files component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://github.com/MetaMask/contract-metadata.git",
+    "adblock-lists": "github:brave/adblock-lists",
     "adblock-rs": "^0.3.17",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -16,7 +16,7 @@ const util = require('../lib/util')
 
 const stageFiles = (componentType, datFile, version, outputDir) => {
   let datFileName
-  
+
   // ad-block components are in the correct folder
   // we don't need to stage the crx files
   if(componentType == 'ad-block-updater') {
@@ -151,9 +151,10 @@ const getNormalizedDATFileName = (datFileName) =>
   datFileName === 'ReferrerWhitelist' ||
   datFileName === 'ExtensionWhitelist' ||
   datFileName === 'Greaselion' ||
+  datFileName === 'debounce' ||
   datFileName === 'messages' ||
-  datFileName === 'AutoplayWhitelist' || 
-  datFileName === 'speedreader-updater' || 
+  datFileName === 'AutoplayWhitelist' ||
+  datFileName === 'speedreader-updater' ||
   datFileName === 'content-stylesheet' ||
   datFileName.endsWith('.bundle') ? 'default' : datFileName
 
@@ -186,6 +187,7 @@ const getDATFileListByComponentType = (componentType) => {
     case 'local-data-files-updater':
       return [path.join('node_modules', 'autoplay-whitelist', 'data', 'AutoplayWhitelist.dat'),
 	      path.join('node_modules', 'extension-whitelist', 'data', 'ExtensionWhitelist.dat'),
+	      path.join('node_modules', 'adblock-lists', 'brave-lists', 'debounce.json'),
 	      path.join('node_modules', 'referrer-whitelist', 'data', 'ReferrerWhitelist.json')].concat(
 		recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')))
     case 'speedreader-updater':


### PR DESCRIPTION
Now that debouncing has landed in master, this will add the new `debounce.json` configuration file to the local data files component.

Dependent on https://github.com/brave/adblock-lists/pull/645 for a package file, but otherwise straightforward.