### PR TITLE
Add automated PR creation on submodule updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+submodules/ @antonok-edm

--- a/.github/workflows/assign-pr.yml
+++ b/.github/workflows/assign-pr.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+name: Assign Pull Request
+jobs:
+  assignAuthor:
+    name: Assign author to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -1,0 +1,17 @@
+name: Submodule Sync
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 12 * * *'
+jobs:
+  submodule-sync:
+    name: Submodule Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submodule Sync
+        uses: mheap/submodule-sync-action@v1
+        with:
+          path: 'submodules/uBlock'
+          ref: master
+          pr_branch: automated-submodule-update
+          target_branch: master


### PR DESCRIPTION
Resolves https://github.com/brave/devops/issues/6097 for Formatting Review

This set of GitHub actions will:

Run periodically at a set schedule (once per day), and check for updates in the uBlock submodule.

If there are updates available, it will trigger the generation of a PR assigned to a specific user defined in codeowners.
