### PR TITLE
Update adblock-rust to v0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       "from": "github:brave/adblock-lists"
     },
     "adblock-rs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.4.1.tgz",
-      "integrity": "sha512-1kqVFtXLwew1hGo3/HRxyoE+INpu1eKZyzdTvS8p0EUy2/jtZCvquK5whqmZU6VnKZv839OSzanK4NfQbmO2ww==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.4.2.tgz",
+      "integrity": "sha512-p/klrFwR1LOADPkHkBBvTdMsNREVtjrz6aennXNXhrqELIdb7arqd1fI++5XbxET8R+JJeBPosrEv2l8jaDKvQ==",
       "requires": {
         "neon-cli": "0.8.3"
       }
@@ -7689,9 +7689,9 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uglify-js": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
-      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.4.tgz",
+      "integrity": "sha512-AbiSR44J0GoCeV81+oxcy/jDOElO2Bx3d0MfQCUShq7JRXaM4KtQopZsq2vFv8bCq2yMaGrw1FgygUd03RyRDA==",
       "optional": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@metamask/contract-metadata": "git+https://github.com/MetaMask/contract-metadata.git",
     "adblock-lists": "github:brave/adblock-lists",
-    "adblock-rs": "^0.4.1",
+    "adblock-rs": "^0.4.2",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "^2.814.0",


### PR DESCRIPTION
This includes a fix for the CSS exfiltration attack described in https://portswigger.net/research/ublock-i-exfiltrate-exploiting-ad-blockers-with-css