### PR TITLE
Update to adblock-rust 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -519,9 +519,9 @@
       "from": "github:brave/adblock-lists"
     },
     "adblock-rs": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.4.3.tgz",
-      "integrity": "sha512-AxM9GxsLqcCSzak5qEQI+kW5RIFSbx2595mj0918eUpmI6I0ekDNxqJ2cVMZ5RsvBd9vbbTDZPgMam5k1m/lUA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/adblock-rs/-/adblock-rs-0.5.0.tgz",
+      "integrity": "sha512-i6Y5wFemjQMVrA/mEuNa4SbsAoAcjZdZ9dPXxvX3PzCQHzPMfOsDetGAZ5U1cevhaj0lpLfoahznxvLNraXrZg==",
       "requires": {
         "neon-cli": "0.8.3"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "adblock-lists": "github:brave/adblock-lists",
-    "adblock-rs": "^0.4.3",
+    "adblock-rs": "^0.5.0",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "2.1047.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
     "adblock-lists": "github:brave/adblock-lists",
-    "adblock-rs": "^0.4.2",
+    "adblock-rs": "^0.4.3",
     "ajv": "^6.10.0",
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "2.1047.0",


### PR DESCRIPTION
`adblock-rust` 0.4.3 adds support for `$doc` as an alias for `$document`. This option alias appears in some lists that Brave uses, but they've been silently ignored so far, as reported in https://github.com/brave/adblock-rust/issues/197.