### PR TITLE
Rewrite script for packaaging wallet data files

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,6 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const request = require('request')
 const s3 = require('s3-client')
-const sharp = require('sharp')
 const unzip = require('unzip-crx-3')
 const AWS = require('aws-sdk')
 
@@ -271,107 +270,6 @@ const createTable = (endpoint, region) => {
   return dynamodb.createTable(params).promise()
 }
 
-async function saveToPNGResize(source, dest, ignoreError) {
-  return new Promise(function (resolve, reject) {
-    sharp(source)
-      .png()
-      .toFile(dest)
-      .then(function(info) {
-        if (info.width > 200 || info.height > 200) {
-          var aspectRatio = 200 / info.width
-          if (info.height > info.width) {
-            aspectRatio = 200 / info.height
-          }
-          var newWidth = Math.round(info.width * aspectRatio)
-          var newHeight = Math.round(info.height * aspectRatio)
-          sharp(source)
-            .png()
-            .resize(newWidth, newHeight)
-            .toFile(dest)
-            .then(function(info) {
-              resolve()
-            })
-            .catch(function(err) {
-              console.log('source == ' + source + ' ' + err)
-              reject()
-            })
-        } else {
-          if ((info.width < 200 || info.height < 200) && !source.endsWith(".png"))  {
-            console.log('resizing vector image == ' + source)
-            var outPutDir = source.substr(0, source.lastIndexOf("/")) + "/resized"
-            var fileName = source.substr(source.lastIndexOf("/") + 1)
-            childProcess.execSync('./node_modules/svg-resizer/svg-resizer.js -f -x 300 -y 300 -o ' + outPutDir + ' -i ' + source)
-            saveToPNGResize(outPutDir + '/' + fileName, dest, true).then(() => {
-              resolve()})
-          } else {
-            resolve()
-          }
-        }
-      })
-      .catch(function(err) {
-        if (ignoreError) {
-          console.log('source == ' + source + ' ' + err)
-          reject()
-          return
-        }
-        console.log('trying one more time source == ' + source + ' ' + err)
-        modifySvgFile(source)
-        saveToPNGResize(source, dest, true).then(() => {
-          resolve()})
-      })
-  })
-}
-
-const modifySvgFile = (file) => {
-  var buf = '<?xml version="1.0" encoding="utf8"?>'
-  var bufToReplace = '<?xml version="1.0" encoding="windows-1252"?>'
-  var data = fs.readFileSync(file).toString()
-  if (data.startsWith(bufToReplace)) {
-    data = buf + data.substring(bufToReplace.length)
-  } else {
-    data = buf + data
-  }
-  fs.writeFileSync(file, data)
-}
-
-const contractReplaceSvgToPng = (file) => {
-  var data = JSON.parse(fs.readFileSync(file))
-  for (var p in data) {
-    if (data.hasOwnProperty(p)) {
-      if (!data[p].logo) {
-        continue
-      }
-      data[p].logo = data[p].logo.substr(0, data[p].logo.lastIndexOf(".")) + ".png"
-    }
-  }
-  fs.writeFileSync(file, JSON.stringify(data, null, 2))
-}
-
-const contractAddExtraAssetIcons = (file, imagesDstPath) => {
-  var data = JSON.parse(fs.readFileSync(file))
-  // CRV
-  data["0xD533a949740bb3306d119CC777fa900bA034cd52"] = {
-    name: "Curve",
-    logo: "curve.png",
-    erc20: true,
-    symbol: "CRV",
-    decimals: 18
-  }
-  fs.copyFileSync("resources/curve.png", path.join(imagesDstPath, "curve.png"))
-  // PDAI
-  data["0x9043d4d51C9d2e31e3F169de4551E416970c27Ef"] = {
-    name: "Palm DAI",
-    logo: "pdai.png",
-    erc20: true,
-    symbol: "PDAI",
-    decimals: 18
-  }
-  fs.copyFileSync("resources/pdai.png", path.join(imagesDstPath, "pdai.png"))
-  // Just copy ETH icon as ETH is not a contract token
-  fs.copyFileSync("resources/eth.png", path.join(imagesDstPath, "eth.png"))
-  fs.writeFileSync(file, JSON.stringify(data, null, 2))
-}
-
 const createTableIfNotExists = (endpoint, region) => {
   const dynamodb = createDynamoDBInstance(endpoint, region)
   return dynamodb.listTables({})
@@ -442,9 +340,6 @@ module.exports = {
   getIDFromBase64PublicKey,
   installErrorHandlers,
   parseManifest,
-  contractReplaceSvgToPng,
-  contractAddExtraAssetIcons,
-  saveToPNGResize,
   uploadCRXFile,
   updateDBForCRXFile
 }

--- a/manifests/wallet-data-files-updater/manifest.json
+++ b/manifests/wallet-data-files-updater/manifest.json
@@ -1,7 +1,0 @@
-{
-  "description": "Data Files in support of the Brave Wallet",
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArxxr39YT+hk6Fo1KEDTe77Vt/ZXr9+b4fKWpltg37Im7HD9TWYg6O7IFmGe19lh+4SPdojB1Fx3b0EVBfKqHRWZz9idqFskUOicOV87BKWp+Q8qiZ5On7a70QeKNBCUAhk/t1ykBzlUm7Mk6kukaIxZmKmY/7czU+W86VG9UpKcX16ANyYRr7zX0alt31PURboEoarnBINmJsT14TsZzi8CW/LJmS5krLO2sPch0Gwt45ogb/1OukuPkwS8wohtJ48byUKu/E+pHbiQ1XGVq3zjL3SVON68DpJdHPEXcPGpOAHCjqu/e0WyJUKf93koaw7b4yZSvu6QJi846OjRVGQIDAQAB",
-  "manifest_version": 2,
-  "name": "Wallet Data Files Updater",
-  "version": "0.0.0"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -837,6 +837,11 @@
         "@types/chrome": "0.0.100"
       }
     },
+    "brave-wallet-lists": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.0.1.tgz",
+      "integrity": "sha512-kSsfaD0EEE4Lq6uiwZmtp746z5CAmkcO6DpmWpUQzQRngCMKNcW7ACM6hHokIcDuMxMMZtC8JPgWGOIeMrPmug=="
+    },
     "browserslist": {
       "version": "4.19.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,10 +376,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@metamask/contract-metadata": {
-      "version": "git+https://github.com/MetaMask/contract-metadata.git#70cf9a447fe2920dcca0205700d130f0b4430234",
-      "from": "git+https://github.com/MetaMask/contract-metadata.git"
-    },
     "@npmcli/fs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
@@ -816,27 +812,6 @@
       "integrity": "sha512-nLEaaz3/sEzNSyPWRsN9HNsqwk1AUyECtGj+XwGdIi3xABnEqecvXtIJ0wehQXuuER5uZ/5fTs2usONgYjG+iw==",
       "dev": true
     },
-    "bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1087,15 +1062,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "color": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.1.0.tgz",
-      "integrity": "sha512-o2rkkxyLGgYoeUy1OodXpbPAQNmlNBrirQ8ODO8QutzDiDMNdezSOZLNnusQ6pUpCQJUsaJIo9DZJKqa2HgH7A==",
-      "requires": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1108,15 +1074,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "color-string": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -1323,14 +1280,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "requires": {
-        "mimic-response": "^3.1.0"
-      }
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -1414,11 +1363,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "4.0.2",
@@ -1507,14 +1451,6 @@
             "ieee754": "^1.1.13"
           }
         }
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
       }
     },
     "enquirer": {
@@ -1850,11 +1786,6 @@
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
       "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
-    },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "extend": {
       "version": "3.0.2",
@@ -2211,11 +2142,6 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
     "fs-exists-cached": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
@@ -2401,11 +2327,6 @@
       "requires": {
         "iniparser": "~1.0.5"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "7.2.0",
@@ -2702,11 +2623,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
     "iniparser": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz",
@@ -2762,11 +2678,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -3531,11 +3442,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
-    "mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3640,11 +3546,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3654,11 +3555,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "napi-macros": {
       "version": "2.0.0",
@@ -3670,11 +3566,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -3728,19 +3619,6 @@
           }
         }
       }
-    },
-    "node-abi": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.5.0.tgz",
-      "integrity": "sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==",
-      "requires": {
-        "semver": "^7.3.5"
-      }
-    },
-    "node-addon-api": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
-      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node-gyp": {
       "version": "5.1.1",
@@ -4381,26 +4259,6 @@
         }
       }
     },
-    "prebuild-install": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
-      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4462,15 +4320,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -4485,17 +4334,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -4848,21 +4686,6 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
-    "sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
-      "requires": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
-        "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4877,11 +4700,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
-      "integrity": "sha1-kEktcv/MgVmXa6umL7D2iE8MM3g="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -4898,29 +4716,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-    },
-    "simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -5429,61 +5224,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
         "has-flag": "^4.0.0"
-      }
-    },
-    "svg-resizer": {
-      "version": "github:brave/svg-resizer#deef469de667429a5cbcfe3ddc8d3cb33460ee4f",
-      "from": "github:brave/svg-resizer",
-      "requires": {
-        "commander": "^2.20.0",
-        "fs-extra": "~0.8.1",
-        "lodash": "^4.17.21",
-        "shelljs": "~0.2.6",
-        "xml2js": "~0.4.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.8.1.tgz",
-          "integrity": "sha1-Dld5/7/t9RG8dVWVx/A8BtS0Po0=",
-          "requires": {
-            "jsonfile": "~1.1.0",
-            "mkdirp": "0.3.x",
-            "ncp": "~0.4.2",
-            "rimraf": "~2.2.0"
-          }
-        },
-        "jsonfile": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
-          "integrity": "sha1-2k/WrXfxolUgPqY8e8Mtwx72RDM="
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
       }
     },
     "table": {
@@ -6913,29 +6659,6 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
-      }
-    },
-    "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
       }
     },
     "tcompare": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
-    "@metamask/contract-metadata": "git+https://github.com/MetaMask/contract-metadata.git",
     "adblock-lists": "github:brave/adblock-lists",
     "adblock-rs": "^0.4.2",
     "ajv": "^6.10.0",
@@ -17,9 +16,7 @@
     "referrer-whitelist": "github:brave/referrer-whitelist",
     "request": "^2.88.0",
     "s3-client": "^4.4.2",
-    "sharp": "^0.29.1",
     "speedreader": "github:brave-experiments/SpeedReader",
-    "svg-resizer": "github:brave/svg-resizer",
     "unzip-crx-3": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "2.1047.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
+    "brave-wallet-lists": "^1.0.1",
     "ethereum-remote-client": "^0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "brave/https-everywhere-builder",


### PR DESCRIPTION
- Makes the wallet data files script easy to maintain
- Adds in https://github.com/brave/token-lists/blob/main/evm-contract-map.json for Ropsten tokens
- Makes it easier to add Solana tokens in another PR.

Please also review the initial work to generate the lists here https://github.com/brave/token-lists/commits/main
The way it works is that repo makes the exact thing we deliver in brave-core-crx-packager and publishes just those json files and images to npm.  Then in this repo we just include that simple dep which has no sub-deps.


Fix: https://github.com/brave/brave-core-crx-packager/issues/307