### PR TITLE
Update `dependencies.brave-site-specific-scripts.version`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -831,7 +831,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "github:brave/brave-site-specific-scripts#b3ddcc3c60dde4853a04780a927ef30787ea7fc4",
+      "version": "github:brave/brave-site-specific-scripts#589fef52a4ba54f70ef669acf1ba36943012ddd4",
       "from": "github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Needed for https://github.com/brave/brave-browser/issues/19594.