### PR TITLE
Support publisher proof

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -331,6 +331,16 @@ const updateDynamoDB = (endpoint, region, id, version, hash, name, disabled) => 
   return dynamodb.putItem(params).promise()
 }
 
+const addCommonScriptOptions = (command) => {
+  return command
+    .option('-b, --binary <binary>',
+      'Path to the Chromium based executable to use to generate the CRX file')
+
+    // If setup locally, use  --endpoint http://localhost:8000
+    .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')
+    .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+}
+
 module.exports = {
   createTableIfNotExists,
   downloadExtensionFromCWS,
@@ -341,5 +351,6 @@ module.exports = {
   installErrorHandlers,
   parseManifest,
   uploadCRXFile,
-  updateDBForCRXFile
+  updateDBForCRXFile,
+  addCommonScriptOptions,
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -29,10 +29,20 @@ const downloadExtensionFromCWS = (componentId, chromiumVersion, outputPath) => {
   })
 }
 
-const generateCRXFile = (binary, crxFile, privateKeyFile, inputDir) => {
-  const args = `--pack-extension=${path.resolve(inputDir)} --pack-extension-key=${path.resolve(privateKeyFile)}`
+const generateCRXFile = (binary, crxFile, privateKeyFile, publisherProofKey,
+  inputDir) => {
+  if (!binary) {
+    throw new Error('Missing Brave binary: --binary')
+  }
+  if (!publisherProofKey) {
+    throw new Error('Missing --publisher-proof-key <file>')
+  }
+  const args = [
+    `--pack-extension=${path.resolve(inputDir)}`,
+    `--pack-extension-key=${path.resolve(privateKeyFile)}`,
+    `--brave-extension-publisher-key=${path.resolve(publisherProofKey)}`];
   const originalOutput = `${inputDir}.crx`
-  childProcess.execSync(`${binary} ${args}`)
+  childProcess.execSync(`${binary} ${args.join(' ')}`)
   fs.renameSync(originalOutput, crxFile)
 }
 
@@ -335,6 +345,8 @@ const addCommonScriptOptions = (command) => {
   return command
     .option('-b, --binary <binary>',
       'Path to the Chromium based executable to use to generate the CRX file')
+    .option('-p, --publisher-proof-key <file>',
+      'File containing private key for generating publisher proof')
 
     // If setup locally, use  --endpoint http://localhost:8000
     .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -77,14 +77,11 @@ const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion, compo
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
-  .option('-t, --target-regions <regions>', 'Comma separated list of regions that should generate SI component. For example: "AU-android,US-desktop,GB-ios"', '')
-  .option('-u, --excluded-target-regions <regions>', 'Comma separated list of regions that should not generate SI component. For example: "AU-android,US-desktop,GB-ios"', '')
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
+    .option('-t, --target-regions <regions>', 'Comma separated list of regions that should generate SI component. For example: "AU-android,US-desktop,GB-ios"', '')
+    .option('-u, --excluded-target-regions <regions>', 'Comma separated list of regions that should not generate SI component. For example: "AU-android,US-desktop,GB-ios"', ''))
   .parse(process.argv)
 
 let keyDir = ''

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -59,7 +59,8 @@ function getManifestPath (regionPlatform) {
   return path.join(getManifestsDir(), `${regionPlatform}-manifest.json`)
 }
 
-const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion, componentData) => {
+const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion,
+                         componentData, publisherProofKey) => {
   const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images')
   const stagingDir = path.join(rootBuildDir, 'staging', platformRegion)
   const crxOutputDir = path.join(rootBuildDir, 'output')
@@ -70,7 +71,8 @@ const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion, compo
     // Desktop private key file names do not have the -desktop suffix, but android has -android
     const privateKeyFile = path.join(keyDir, `ntp-sponsored-images-${platformRegion.replace('-desktop', '')}.pem`)
     stageFiles(platformRegion, version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -91,16 +93,14 @@ if (fs.existsSync(commander.keysDirectory)) {
   throw new Error('Missing or invalid private key directory')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 const targetComponents = params.getTargetComponents(commander.targetRegions, commander.excludedTargetRegions)
 
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   for (const platformRegion of Object.keys(targetComponents)) {
     const componentData = targetComponents[platformRegion]
     generateManifestFile(platformRegion, componentData)
-    generateCRXFile(commander.binary, commander.endpoint, commander.region, keyDir, platformRegion, componentData)
+    generateCRXFile(commander.binary, commander.endpoint, commander.region,
+                    keyDir, platformRegion, componentData,
+                    commander.publisherProofKey)
   }
 })

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -91,7 +91,8 @@
    return path.join(getManifestsDir(), `${locale}-manifest.json`)
  }
 
- const generateCRXFile = (binary, endpoint, region, keyDir, componentData) => {
+ const generateCRXFile = (binary, endpoint, region, keyDir,  publisherProofKey,
+                          componentData) => {
    const originalManifest = getOriginalManifest(componentData.locale)
    const locale = componentData.locale
    const rootBuildDir = path.join(path.resolve(), 'build', 'user-model-installer')
@@ -103,7 +104,8 @@
      const crxFile = path.join(crxOutputDir, `user-model-installer-${locale}.crx`)
      const privateKeyFile = path.join(keyDir, `user-model-installer-${locale}.pem`)
      stageFiles(locale, version, stagingDir)
-     util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+     util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                          stagingDir)
      console.log(`Generated ${crxFile} with version number ${version}`)
    })
  }
@@ -122,11 +124,10 @@
    throw new Error('Missing or invalid private key directory')
  }
 
- if (!commander.binary) {
-   throw new Error('Missing Chromium binary: --binary')
- }
-
  util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
    generateManifestFiles()
-   getComponentDataList().forEach(generateCRXFile.bind(null, commander.binary, commander.endpoint, commander.region, keyDir))
+   getComponentDataList().forEach(
+     generateCRXFile.bind(null, commander.binary, commander.endpoint,
+                          commander.region, keyDir,
+                          commander.publisherProofKey))
  })

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -110,12 +110,9 @@
 
  util.installErrorHandlers()
 
- commander
-   .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-   .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-   .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
-   .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-   .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+ util.addCommonScriptOptions(
+   commander
+     .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files'))
    .parse(process.argv)
 
  let keyDir = ''

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -200,7 +200,8 @@ const getDATFileListByComponentType = (componentType) => {
   }
 }
 
-const postNextVersionWork = (componentType, datFileName, key, binary, localRun, datFile, version) => {
+const postNextVersionWork = (componentType, datFileName, key, publisherProofKey,
+                             binary, localRun, datFile, version) => {
   const stagingDir = path.join('build', componentType, datFileName)
   const crxOutputDir = path.join('build', componentType)
   const crxFile = path.join(crxOutputDir, datFileName ? `${componentType}-${datFileName}.crx` : `${componentType}.crx`)
@@ -210,13 +211,15 @@ const postNextVersionWork = (componentType, datFileName, key, binary, localRun, 
   }
   stageFiles(componentType, datFile, version, stagingDir).then(() => {
     if (!localRun) {
-      util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+      util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                           stagingDir)
     }
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
 
-const processDATFile = (binary, endpoint, region, componentType, key, localRun, datFile) => {
+const processDATFile = (binary, endpoint, region, componentType, key,
+                        publisherProofKey, localRun, datFile) => {
   var datFileName = getNormalizedDATFileName(path.parse(datFile).name)
   if (componentType == 'ad-block-updater') {
     // we need the last (build/ad-block-updater/<uuid>) folder name for ad-block-updater
@@ -229,17 +232,22 @@ const processDATFile = (binary, endpoint, region, componentType, key, localRun, 
 
   if (!localRun) {
     util.getNextVersion(endpoint, region, id).then((version) => {
-      postNextVersionWork(componentType, datFileName, key, binary, localRun, datFile, version)
+      postNextVersionWork(componentType, datFileName, key, publisherProofKey,
+                          binary, localRun, datFile, version)
     })
   } else {
-    postNextVersionWork(componentType, datFileName, key, binary, localRun, datFile, '1.0.0')
+    postNextVersionWork(componentType, datFileName, key, publisherProofKey,
+                        binary, localRun, datFile, '1.0.0')
   }
 }
 
 const processJob = (commander, keyParam) => {
   generateManifestFilesByComponentType(commander.type)
   getDATFileListByComponentType(commander.type)
-    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint, commander.region, commander.type, keyParam, commander.localRun))
+    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint,
+                                 commander.region, commander.type, keyParam,
+                                 commander.publisherProofKey,
+                                 commander.localRun))
 }
 
 util.installErrorHandlers()
@@ -262,10 +270,6 @@ if (!commander.localRun) {
   } else {
     throw new Error('Missing or invalid private key file/directory')
   }
-}
-
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
 }
 
 if (!commander.localRun) {

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -244,15 +244,12 @@ const processJob = (commander, keyParam) => {
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
-  .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-  .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater|ethereum-remote-client|wallet-data-files-updater|speedreader-updater)$/i, 'ad-block-updater')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
-  .option('-l, --local-run', 'Runs updater job without connecting anywhere remotely')
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
+    .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
+    .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater|ethereum-remote-client|wallet-data-files-updater|speedreader-updater)$/i, 'ad-block-updater')
+    .option('-l, --local-run', 'Runs updater job without connecting anywhere remotely'))
   .parse(process.argv)
 
 let keyParam = ''

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -63,13 +63,10 @@ const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
-  .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
+    .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem'))
   .parse(process.argv)
 
 let keyParam = ''

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -24,7 +24,8 @@ const getOriginalManifest = (platform) => {
   return path.join('manifests', 'ipfs-daemon-updater', `ipfs-daemon-updater-${platform}-manifest.json`)
 }
 
-const packageIpfsDaemon = (binary, endpoint, region, os, arch, key) => {
+const packageIpfsDaemon = (binary, endpoint, region, os, arch, key,
+                           publisherProofKey) => {
   const platform = `${os}-${arch}`
   const originalManifest = getOriginalManifest(platform)
   const parsedManifest = util.parseManifest(originalManifest)
@@ -37,7 +38,8 @@ const packageIpfsDaemon = (binary, endpoint, region, os, arch, key) => {
     const crxFile = path.join(crxOutputDir, `ipfs-daemon-updater-${platform}.crx`)
     const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `ipfs-daemon-updater-${platform}.pem`)
     stageFiles(platform, ipfsDaemon, version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -79,13 +81,13 @@ if (fs.existsSync(commander.keyFile)) {
   throw new Error('Missing or invalid private key file/directory')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'darwin', 'amd64', keyParam)
-  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'linux', 'amd64', keyParam)
-  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'win32', 'amd64', keyParam)
-  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region, 'darwin', 'arm64', keyParam)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region,
+                    'darwin', 'amd64', keyParam, commander.publisherProofKey)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region,
+                    'linux', 'amd64', keyParam, commander.publisherProofKey)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region,
+                    'win32', 'amd64', keyParam, commander.publisherProofKey)
+  packageIpfsDaemon(commander.binary, commander.endpoint, commander.region,
+                    'darwin', 'arm64', keyParam, commander.publisherProofKey)
 })

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -63,12 +63,9 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-k, --key <file>', 'file containing private key for signing crx file')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key <file>', 'file containing private key for signing crx file'))
   .parse(process.argv)
 
 let privateKeyFile = ''

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -46,7 +46,8 @@ const getOriginalManifest = () => {
   return path.join(path.resolve(), 'build','ntp-background-images', 'ntp-background-images-manifest.json')
 }
 
-const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) => {
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+                         publisherProofKey) => {
   const originalManifest = getOriginalManifest()
   const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-background-images')
   const stagingDir = path.join(rootBuildDir, 'staging')
@@ -56,7 +57,8 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
  util.getNextVersion(endpoint, region, componentID).then((version) => {
     const crxFile = path.join(crxOutputDir, `ntp-background-images.crx`)
     stageFiles(version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
  })
 }
@@ -75,12 +77,9 @@ if (fs.existsSync(commander.key)) {
   throw new Error('Missing or invalid private key')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
   generateManifestFile(publicKey)
-  generateCRXFile(commander.binary, commander.endpoint, commander.region, componentID, privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+                  componentID, privateKeyFile, commander.publisherProofKey)
 })

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -47,7 +47,8 @@ const getOriginalManifest = (superReferrerName) => {
   return path.join(path.resolve(), 'build','ntp-super-referrer', `${superReferrerName}-manifest.json`)
 }
 
-const generateCRXFile = (binary, endpoint, region, superReferrerName, componentID, privateKeyFile) => {
+const generateCRXFile = (binary, endpoint, region, superReferrerName,
+                         componentID, privateKeyFile, publisherProofKey) => {
   const originalManifest = getOriginalManifest(superReferrerName)
   const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-super-referrer')
   const stagingDir = path.join(rootBuildDir, 'staging', superReferrerName)
@@ -57,7 +58,8 @@ const generateCRXFile = (binary, endpoint, region, superReferrerName, componentI
   util.getNextVersion(endpoint, region, componentID).then((version) => {
     const crxFile = path.join(crxOutputDir, `ntp-super-referrer-${superReferrerName}.crx`)
     stageFiles(superReferrerName, version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -77,12 +79,10 @@ if (fs.existsSync(commander.key)) {
   throw new Error('Missing or invalid private key')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
   generateManifestFile(commander.superReferrerName, publicKey)
-  generateCRXFile(commander.binary, commander.endpoint, commander.region, commander.superReferrerName, componentID, privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+                  commander.superReferrerName, componentID, privateKeyFile,
+                  commander.publisherProofKey)
 })

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -64,13 +64,10 @@ const generateCRXFile = (binary, endpoint, region, superReferrerName, componentI
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-n, --super-referrer-name <name>', 'super referrer name for this component')
-  .option('-k, --key <file>', 'file containing private key for signing crx file')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-n, --super-referrer-name <name>', 'super referrer name for this component')
+    .option('-k, --key <file>', 'file containing private key for signing crx file'))
   .parse(process.argv)
 
 let privateKeyFile = ''

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -64,12 +64,9 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-k, --key <file>', 'file containing private key for signing crx file')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key <file>', 'file containing private key for signing crx file'))
   .parse(process.argv)
 
 let privateKeyFile = ''

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -47,7 +47,8 @@ const getOriginalManifest = () => {
   return path.join(path.resolve(), 'build','ntp-super-referrer', 'mapping-table-manifest.json')
 }
 
-const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) => {
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+                         publisherProofKey) => {
   const originalManifest = getOriginalManifest()
   const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-super-referrer', 'mapping-table')
   const stagingDir = path.join(rootBuildDir, 'staging')
@@ -57,7 +58,8 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
   util.getNextVersion(endpoint, region, componentID).then((version) => {
     const crxFile = path.join(crxOutputDir, `ntp-super-referrer-mapping-table.crx`)
     stageFiles(version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -76,12 +78,9 @@ if (fs.existsSync(commander.key)) {
   throw new Error('Missing or invalid private key')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
   generateManifestFile(publicKey)
-  generateCRXFile(commander.binary, commander.endpoint, commander.region, componentID, privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+                  componentID, privateKeyFile, commander.publisherProofKey)
 })

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -114,13 +114,10 @@ const verifyChecksum = (file, hash) => {
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
-  .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files', 'abc')
+    .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem'))
   .parse(process.argv)
 
 let keyParam = ''

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -65,7 +65,8 @@ const getOriginalManifest = (platform) => {
   return path.join('manifests', 'tor-client-updater', `tor-client-updater-${platform}-manifest.json`)
 }
 
-const packageTorClient = (binary, endpoint, region, platform, key) => {
+const packageTorClient = (binary, endpoint, region,platform, key,
+                          publisherProofKey) => {
   const originalManifest = getOriginalManifest(platform)
   const parsedManifest = util.parseManifest(originalManifest)
   const id = util.getIDFromBase64PublicKey(parsedManifest.key)
@@ -77,7 +78,8 @@ const packageTorClient = (binary, endpoint, region, platform, key) => {
     const crxFile = path.join(crxOutputDir, `tor-client-updater-${platform}.crx`)
     const privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `tor-client-updater-${platform}.pem`)
     stageFiles(platform, torClient, version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -130,12 +132,11 @@ if (fs.existsSync(commander.keyFile)) {
   throw new Error('Missing or invalid private key file/directory')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  packageTorClient(commander.binary, commander.endpoint, commander.region, 'darwin', keyParam)
-  packageTorClient(commander.binary, commander.endpoint, commander.region, 'linux', keyParam)
-  packageTorClient(commander.binary, commander.endpoint, commander.region, 'win32', keyParam)
+  packageTorClient(commander.binary, commander.endpoint, commander.region,
+                   'darwin', keyParam, commander.publisherProofKey)
+  packageTorClient(commander.binary, commander.endpoint, commander.region,
+                   'linux', keyParam, commander.publisherProofKey)
+  packageTorClient(commander.binary, commander.endpoint, commander.region,
+                   'win32', keyParam, commander.publisherProofKey)
 })

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -49,7 +49,8 @@ const getOriginalManifest = () => {
   return getOutPath('youtubedown-manifest.json')
 }
 
-const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) => {
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+                         publisherProofKey) => {
   const originalManifest = getOriginalManifest()
   const rootBuildDir = path.join(path.resolve(), 'build', 'youtubedown')
   const stagingDir = path.join(rootBuildDir, 'staging')
@@ -59,7 +60,8 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
   util.getNextVersion(endpoint, region, componentID).then((version) => {
     const crxFile = path.join(crxOutputDir, 'youtubedown.crx')
     stageFiles(version, stagingDir)
-    util.generateCRXFile(binary, crxFile, privateKeyFile, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+                         stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
   })
 }
@@ -78,11 +80,8 @@ if (fs.existsSync(commander.key)) {
   throw new Error('Missing or invalid private key')
 }
 
-if (!commander.binary) {
-  throw new Error('Missing Chromium binary: --binary')
-}
-
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
   const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
-  generateCRXFile(commander.binary, commander.endpoint, commander.region, componentID, privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+                  componentID, privateKeyFile, commander.publisherProofKey)
 })

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -66,12 +66,9 @@ const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile) 
 
 util.installErrorHandlers()
 
-commander
-  .option('-b, --binary <binary>', 'Path to the Chromium based executable to use to generate the CRX file')
-  .option('-p, --publisher-proof-key <file>', 'Not used now, for backward compatibility')
-  .option('-k, --key <file>', 'file containing private key for signing crx file')
-  .option('-e, --endpoint <endpoint>', 'DynamoDB endpoint to connect to', '')// If setup locally, use http://localhost:8000
-  .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key <file>', 'file containing private key for signing crx file'))
   .parse(process.argv)
 
 let privateKeyFile = ''


### PR DESCRIPTION
Relates https://github.com/brave/brave-browser/issues/873

Devops PR: https://github.com/brave/devops/pull/6965

The purpose of this PR is to add extra signing (a publisher proof) to all brave CRX.
The plan:
[DONE] (brave-core) [add code to generate  and verify a publisher proof](https://github.com/brave/brave-core/pull/12090)
[DONE] (devops) add new credentials
[in progress](devops) change browser from Chrome to Brave (maybe Brave Nightly?)
[in progress] (devops) pass the credentials to  [brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager) signing scripts
[here] (brave-core-crx-packager) pass the new key to Brave (when we making crx by passing a special command-line)

The devops changes is in progress