### PR TITLE
Revert "Update dependency brave-wallet-lists to v1.0.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
       }
     },
     "brave-wallet-lists": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.0.2.tgz",
-      "integrity": "sha512-yahVH79MRmVSHIWEHPQMFjdT3rI4eN/XmAFtNzae88YVNHmgKI632XA6A1JzEHxgikbPzHsYXSlnzOK5VdtBAg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.0.1.tgz",
+      "integrity": "sha512-kSsfaD0EEE4Lq6uiwZmtp746z5CAmkcO6DpmWpUQzQRngCMKNcW7ACM6hHokIcDuMxMMZtC8JPgWGOIeMrPmug=="
     },
     "browserslist": {
       "version": "4.19.1",
@@ -2262,9 +2262,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
             }
           }
         }
@@ -6488,9 +6488,9 @@
               },
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                  "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                   "dev": true
                 }
               }
@@ -6906,9 +6906,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
             }
           }
         },
@@ -6999,9 +6999,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "2.1047.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "brave-wallet-lists": "1.0.2",
+    "brave-wallet-lists": "^1.0.1",
     "ethereum-remote-client": "^0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "brave/https-everywhere-builder",


### PR DESCRIPTION
Reverts brave/brave-core-crx-packager#344

Per @linhkikuchi:
```
this PR make new build failing https://github.com/brave/brave-core-crx-packager/pull/344/files,
we have this issue before, need to revert this. cc @simonhong can you update dependencies
and fix error so that we will not run into this again?
```