### PR TITLE
Bump brave-wallet-lists to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
       }
     },
     "brave-wallet-lists": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.0.1.tgz",
-      "integrity": "sha512-kSsfaD0EEE4Lq6uiwZmtp746z5CAmkcO6DpmWpUQzQRngCMKNcW7ACM6hHokIcDuMxMMZtC8JPgWGOIeMrPmug=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.0.2.tgz",
+      "integrity": "sha512-yahVH79MRmVSHIWEHPQMFjdT3rI4eN/XmAFtNzae88YVNHmgKI632XA6A1JzEHxgikbPzHsYXSlnzOK5VdtBAg=="
     },
     "browserslist": {
       "version": "4.19.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "autoplay-whitelist": "github:brave/autoplay-whitelist",
     "aws-sdk": "2.1047.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "brave-wallet-lists": "^1.0.1",
+    "brave-wallet-lists": "^1.0.2",
     "ethereum-remote-client": "^0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "brave/https-everywhere-builder",


### PR DESCRIPTION
Follow-up on https://github.com/brave/brave-core-crx-packager/pull/344. Manually bumped the version and performed `npm install` with npm version 6.14.0 to avoid upgrade to new lockfile format.