### PR TITLE
Output iOS cosmetic filter rules to `build\ad-block-updater\ios` not …

### DIFF
--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -151,7 +151,7 @@ const generateDataFilesForList = (lists, filename) => {
   p = p.then((listBuffers) => {
     generateDataFileFromLists(listBuffers, filename, 'default')
     // for iOS team - compile cosmetic filters only
-    generateDataFileFromLists(listBuffers, 'ios-cosmetic-filters.dat', 'default', RuleTypes.COSMETIC_ONLY)
+    generateDataFileFromLists(listBuffers, 'ios-cosmetic-filters.dat', 'ios', RuleTypes.COSMETIC_ONLY)
   })
   p = p.then(() => generateResourcesFile(getOutPath('resources.json', 'default')))
   return p


### PR DESCRIPTION
…`build\ad-block-updater\default`

Fixes https://github.com/brave/brave-core-crx-packager/issues/368