### PR TITLE
Update iOS cosmetic filter output to be in test-data folder

### DIFF
--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -151,7 +151,7 @@ const generateDataFilesForList = (lists, filename) => {
   p = p.then((listBuffers) => {
     generateDataFileFromLists(listBuffers, filename, 'default')
     // for iOS team - compile cosmetic filters only
-    generateDataFileFromLists(listBuffers, 'ios-cosmetic-filters.dat', 'ios', RuleTypes.COSMETIC_ONLY)
+    generateDataFileFromLists(listBuffers, 'ios-cosmetic-filters.dat', 'test-data', RuleTypes.COSMETIC_ONLY)
   })
   p = p.then(() => generateResourcesFile(getOutPath('resources.json', 'default')))
   return p


### PR DESCRIPTION
Fixes https://github.com/brave/brave-core-crx-packager/issues/370

This will be ignored by packageComponent.js
See `getDATFileListByComponentType` where `test-data` folder is excluded