### PR TITLE
Update brave-site-specific-scripts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,7 +1152,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+https://git@github.com/brave/brave-site-specific-scripts.git#589fef52a4ba54f70ef669acf1ba36943012ddd4",
+      "version": "git+https://git@github.com/brave/brave-site-specific-scripts.git#6f59813b833104234caa0f7ed2a0926526cc96ab",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Updates `brave-site-specific-scripts` to version `v1.1.0`, which includes:

* https://github.com/brave/brave-site-specific-scripts/pull/69