### PR TITLE
bump brave-wallet-lists to 1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ajv": "8.11.0",
         "aws-sdk": "2.1147.0",
         "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-        "brave-wallet-lists": "1.1.4",
+        "brave-wallet-lists": "1.1.6",
         "ethereum-remote-client": "0.1.107",
         "extension-whitelist": "github:brave/extension-whitelist",
         "https-everywhere-builder": "github:brave/https-everywhere-builder",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/brave-wallet-lists": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.4.tgz",
-      "integrity": "sha512-KBa7Es9oKsSttTYd3hCyDvc4ObtIp6i5DAwwp725lvk3rJE0sUXJ2oxBy8zNmnqJY6CP1HPU6b2XQG6iFIB9OA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.6.tgz",
+      "integrity": "sha512-sYzsaRyy5Ihr5SWZNk+LP1p/Fb1iByIAYV4gM8ftD0f07f2izK4zfv9K7GHoBYg6FUUFTKISamUeVqJpQZFshQ=="
     },
     "node_modules/browser-level": {
       "version": "1.0.1",
@@ -10353,9 +10353,9 @@
       }
     },
     "brave-wallet-lists": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.4.tgz",
-      "integrity": "sha512-KBa7Es9oKsSttTYd3hCyDvc4ObtIp6i5DAwwp725lvk3rJE0sUXJ2oxBy8zNmnqJY6CP1HPU6b2XQG6iFIB9OA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.6.tgz",
+      "integrity": "sha512-sYzsaRyy5Ihr5SWZNk+LP1p/Fb1iByIAYV4gM8ftD0f07f2izK4zfv9K7GHoBYg6FUUFTKISamUeVqJpQZFshQ=="
     },
     "browser-level": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,6 +1724,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/command-line-usage/node_modules/array-back": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
@@ -1744,6 +1755,19 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/command-line-usage/node_modules/has-flag": {
       "version": "3.0.0",
@@ -8389,6 +8413,15 @@
         "strip-ansi": "^3.0.1"
       }
     },
+    "node_modules/tap/node_modules/unicode-length/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tap/node_modules/unicode-length/node_modules/strip-ansi": {
       "version": "3.0.1",
       "dev": true,
@@ -8397,16 +8430,6 @@
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap/node_modules/unicode-length/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10669,6 +10692,14 @@
         "typical": "^5.2.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "array-back": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
@@ -10683,6 +10714,19 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "has-flag": {
           "version": "3.0.0",
@@ -15383,21 +15427,17 @@
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-                  "bundled": true,
-                  "dev": true
-                }
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ajv": "8.11.0",
     "aws-sdk": "2.1147.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "brave-wallet-lists": "1.1.4",
+    "brave-wallet-lists": "1.1.6",
     "ethereum-remote-client": "0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "github:brave/https-everywhere-builder",


### PR DESCRIPTION
brave-wallet-lists was updated to 1.1.6 here https://github.com/brave/token-lists/pull/14
Also had such ci failures, hence package_lock updates
```
Run npm ci
npm ERR! code EUSAGE
npm ERR! 
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! Missing: ansi-styles@3.2.1 from lock file
npm ERR! Missing: color-convert@1.9.3 from lock file
npm ERR! Missing: color-name@1.1.3 from lock file
npm ERR! 
npm ERR! Clean install a project
npm ERR! 
npm ERR! Usage:
npm ERR! npm ci
npm ERR! 
npm ERR! Options:
npm ERR! [--no-audit] [--foreground-scripts] [--ignore-scripts]
npm ERR! [--script-shell <script-shell>]
npm ERR! 
npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
npm ERR! 
npm ERR! Run "npm help ci" for more info
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-06-22T16_11_[4](https://github.com/brave/brave-core-crx-packager/runs/7008174269?check_suite_focus=true#step:5:5)1_0[7](https://github.com/brave/brave-core-crx-packager/runs/7008174269?check_suite_focus=true#step:5:8)[8](https://github.com/brave/brave-core-crx-packager/runs/7008174269?check_suite_focus=true#step:5:9)Z-debug-0.log
Error: Process completed with exit code 1.
```