### PR TITLE
Bump brave-wallet-lists to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "8.11.0",
         "aws-sdk": "2.1171.0",
         "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-        "brave-wallet-lists": "1.1.6",
+        "brave-wallet-lists": "1.1.7",
         "ethereum-remote-client": "0.1.107",
         "extension-whitelist": "github:brave/extension-whitelist",
         "https-everywhere-builder": "github:brave/https-everywhere-builder",
@@ -1290,9 +1290,9 @@
       }
     },
     "node_modules/brave-wallet-lists": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.6.tgz",
-      "integrity": "sha512-sYzsaRyy5Ihr5SWZNk+LP1p/Fb1iByIAYV4gM8ftD0f07f2izK4zfv9K7GHoBYg6FUUFTKISamUeVqJpQZFshQ=="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.7.tgz",
+      "integrity": "sha512-uiC1QPaFMTII92yweZ4KdodwbnHD2KT9InVkTUIYhNHJLu3zJcj5PnA2Ypu2PMEe7Z6Tnig4WPeO/Wc3VByCQA=="
     },
     "node_modules/browser-level": {
       "version": "1.0.1",
@@ -10336,9 +10336,9 @@
       }
     },
     "brave-wallet-lists": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.6.tgz",
-      "integrity": "sha512-sYzsaRyy5Ihr5SWZNk+LP1p/Fb1iByIAYV4gM8ftD0f07f2izK4zfv9K7GHoBYg6FUUFTKISamUeVqJpQZFshQ=="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.7.tgz",
+      "integrity": "sha512-uiC1QPaFMTII92yweZ4KdodwbnHD2KT9InVkTUIYhNHJLu3zJcj5PnA2Ypu2PMEe7Z6Tnig4WPeO/Wc3VByCQA=="
     },
     "browser-level": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ajv": "8.11.0",
     "aws-sdk": "2.1171.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "brave-wallet-lists": "1.1.6",
+    "brave-wallet-lists": "1.1.7",
     "ethereum-remote-client": "0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "github:brave/https-everywhere-builder",


### PR DESCRIPTION
brave-wallet-lists was updated to 1.1.7 here https://github.com/brave/token-lists/pull/15

Resolves https://github.com/brave/brave-browser/issues/23823