### PR TITLE
Move ad-block-updater packaging into its own script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint": "standard",
     "import-cws-components": "node ./scripts/importCWSComponents",
     "package-ethereum-remote-client": "node ./scripts/packageComponent --type ethereum-remote-client",
-    "package-ad-block": "node ./scripts/packageComponent --type ad-block-updater",
+    "package-ad-block": "node ./scripts/packageAdBlock",
     "package-https-everywhere": "node ./scripts/packageComponent --type https-everywhere-updater",
     "package-tor-client": "node ./scripts/packageTorClient",
     "package-tor-pluggable-transports": "node ./scripts/packageTorPluggableTransports",

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+//  npm run package-ad-block -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/ad-block-updater-regional-component-keys
+
+const commander = require('commander')
+const fs = require('fs-extra')
+const path = require('path')
+const recursive = require('recursive-readdir-sync')
+const replace = require('replace-in-file')
+const util = require('../lib/util')
+
+async function stageFiles (version, outputDir) {
+  // ad-block components are in the correct folder
+  // we don't need to stage the crx files
+  const resourceFileName = 'resources.json'
+  const resourceJsonPath = path.join('build', 'ad-block-updater', 'default', resourceFileName)
+  const outputManifest = path.join(outputDir, 'manifest.json')
+  const outputResourceJSON = path.join(outputDir, resourceFileName)
+  const replaceOptions = {
+    files: outputManifest,
+    from: /0\.0\.0/,
+    to: version
+  }
+  replace.sync(replaceOptions)
+  if (resourceJsonPath !== outputResourceJSON) {
+    fs.copyFileSync(resourceJsonPath, outputResourceJSON)
+  }
+}
+
+const postNextVersionWork = (datFileName, key, publisherProofKey,
+  binary, localRun, version) => {
+  const stagingDir = path.join('build', 'ad-block-updater', datFileName)
+  const crxOutputDir = path.join('build', 'ad-block-updater')
+  const crxFile = path.join(crxOutputDir, datFileName ? `ad-block-updater-${datFileName}.crx` : `ad-block-updater.crx`)
+  let privateKeyFile = ''
+  if (!localRun) {
+    privateKeyFile = path.join(key, datFileName ? `ad-block-updater-${datFileName}.pem` : `ad-block-updater.pem`)
+  }
+  stageFiles(version, stagingDir).then(() => {
+    if (!localRun) {
+      util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+        stagingDir)
+    }
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+const getOriginalManifest = (datFileName) => {
+  manifestsDir = path.join('build', 'ad-block-updater')
+  return path.join(manifestsDir, datFileName, 'manifest.json')
+}
+
+const processDATFile = (binary, endpoint, region, keyDir,
+  publisherProofKey, localRun, datFile) => {
+  // we need the last (build/ad-block-updater/<uuid>) folder name
+  const datFileName = path.dirname(datFile).split(path.sep).pop()
+
+  const originalManifest = getOriginalManifest(datFileName)
+  const parsedManifest = util.parseManifest(originalManifest)
+  const id = util.getIDFromBase64PublicKey(parsedManifest.key)
+
+  if (!localRun) {
+    util.getNextVersion(endpoint, region, id).then((version) => {
+      postNextVersionWork(datFileName, keyDir, publisherProofKey,
+        binary, localRun, version)
+    })
+  } else {
+    postNextVersionWork(datFileName, undefined, publisherProofKey,
+      binary, localRun, '1.0.0')
+  }
+}
+
+const getDATFileList = () => {
+  return recursive(path.join('build', 'ad-block-updater'))
+    .filter(file => {
+      return (path.extname(file) === '.dat' && !file.includes('test-data'))
+    })
+    .reduce((acc, val) => {
+      acc.push(path.join(val))
+      return acc
+    }, [])
+}
+
+const processJob = (commander, keyDir) => {
+  getDATFileList()
+    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint,
+      commander.region, keyDir,
+      commander.publisherProofKey,
+      commander.localRun))
+}
+
+util.installErrorHandlers()
+
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
+    .option('-l, --local-run', 'Runs updater job without connecting anywhere remotely'))
+  .parse(process.argv)
+
+if (!commander.localRun) {
+  let keyDir = ''
+  if (fs.existsSync(commander.keysDirectory)) {
+    keyDir = commander.keysDirectory
+  } else {
+    throw new Error('Missing or invalid private key file/directory')
+  }
+  util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+    processJob(commander, keyDir)
+  })
+} else {
+  processJob(commander, undefined)
+}

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -1,4 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
@@ -34,10 +35,10 @@ const postNextVersionWork = (datFileName, key, publisherProofKey,
   binary, localRun, version) => {
   const stagingDir = path.join('build', 'ad-block-updater', datFileName)
   const crxOutputDir = path.join('build', 'ad-block-updater')
-  const crxFile = path.join(crxOutputDir, datFileName ? `ad-block-updater-${datFileName}.crx` : `ad-block-updater.crx`)
+  const crxFile = path.join(crxOutputDir, datFileName ? `ad-block-updater-${datFileName}.crx` : 'ad-block-updater.crx')
   let privateKeyFile = ''
   if (!localRun) {
-    privateKeyFile = path.join(key, datFileName ? `ad-block-updater-${datFileName}.pem` : `ad-block-updater.pem`)
+    privateKeyFile = path.join(key, datFileName ? `ad-block-updater-${datFileName}.pem` : 'ad-block-updater.pem')
   }
   stageFiles(version, stagingDir).then(() => {
     if (!localRun) {
@@ -49,7 +50,7 @@ const postNextVersionWork = (datFileName, key, publisherProofKey,
 }
 
 const getOriginalManifest = (datFileName) => {
-  manifestsDir = path.join('build', 'ad-block-updater')
+  const manifestsDir = path.join('build', 'ad-block-updater')
   return path.join(manifestsDir, datFileName, 'manifest.json')
 }
 

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -82,6 +82,9 @@ const getDATFileVersionByComponentType = (componentType) => {
           'speedreader',
           'data',
           'default-manifest.json')).toString()).data_file_version
+    default:
+      // shouldn't be possible to get here
+      return null
   }
 }
 
@@ -101,10 +104,15 @@ const getManifestsDirByComponentType = (componentType) => {
       return path.join('node_modules', 'brave-wallet-lists')
     case 'https-everywhere-updater':
     case 'local-data-files-updater':
-      // TODO(emerick): Make these work like ad-block
+      // TODO(emerick): Make these work like ad-block (i.e., update
+      // the corresponding repos with a script to generate the
+      // manifest and then call that script here)
       return path.join('manifests', componentType)
     case 'speedreader-updater':
       return path.join('node_modules', 'speedreader', 'data')
+    default:
+      // shouldn't be possible to get here
+      return null
   }
 }
 
@@ -138,6 +146,9 @@ const getDATFileListByComponentType = (componentType) => {
     case 'speedreader-updater':
       return [path.join('node_modules', 'speedreader', 'data', 'speedreader-updater.dat'),
         path.join('node_modules', 'speedreader', 'data', 'content-stylesheet.css')]
+    default:
+      // shouldn't be possible to get here
+      return null
   }
 }
 
@@ -161,7 +172,7 @@ const postNextVersionWork = (componentType, datFileName, key, publisherProofKey,
 
 const processDATFile = (binary, endpoint, region, componentType, key,
   publisherProofKey, localRun, datFile) => {
-  let datFileName = getNormalizedDATFileName(path.parse(datFile).name)
+  const datFileName = getNormalizedDATFileName(path.parse(datFile).name)
 
   const originalManifest = getOriginalManifest(componentType, datFileName)
   const parsedManifest = util.parseManifest(originalManifest)

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Example usage:
-//  npm run package-ad-block -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/ad-block-updater.pem
+//  npm run package-speedreader -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/speedreader-updater.pem
 
 const commander = require('commander')
 const fs = require('fs-extra')
@@ -15,25 +15,6 @@ const util = require('../lib/util')
 
 async function stageFiles (componentType, datFile, version, outputDir) {
   let datFileName
-
-  // ad-block components are in the correct folder
-  // we don't need to stage the crx files
-  if (componentType === 'ad-block-updater') {
-    const resourceFileName = 'resources.json'
-    const resourceJsonPath = path.join('build', componentType, 'default', resourceFileName)
-    const outputManifest = path.join(outputDir, 'manifest.json')
-    const outputResourceJSON = path.join(outputDir, resourceFileName)
-    const replaceOptions = {
-      files: outputManifest,
-      from: /0\.0\.0/,
-      to: version
-    }
-    replace.sync(replaceOptions)
-    if (resourceJsonPath !== outputResourceJSON) {
-      fs.copyFileSync(resourceJsonPath, outputResourceJSON)
-    }
-    return
-  }
 
   if (componentNeedsStraightCopyFromUnpackedDir(componentType)) {
     const originalDir = getManifestsDirByComponentType(componentType)
@@ -90,8 +71,6 @@ const getDATFileVersionByComponentType = (componentType) => {
     case 'ethereum-remote-client':
     case 'wallet-data-files-updater':
       return '0'
-    case 'ad-block-updater':
-      return ''
     case 'https-everywhere-updater':
       return '6.0'
     case 'local-data-files-updater':
@@ -109,7 +88,6 @@ const getDATFileVersionByComponentType = (componentType) => {
 const validComponentTypes = [
   'ethereum-remote-client',
   'wallet-data-files-updater',
-  'ad-block-updater',
   'https-everywhere-updater',
   'local-data-files-updater',
   'speedreader-updater'
@@ -121,8 +99,6 @@ const getManifestsDirByComponentType = (componentType) => {
       return path.join('node_modules', 'ethereum-remote-client')
     case 'wallet-data-files-updater':
       return path.join('node_modules', 'brave-wallet-lists')
-    case 'ad-block-updater':
-      return path.join('build', 'ad-block-updater')
     case 'https-everywhere-updater':
     case 'local-data-files-updater':
       // TODO(emerick): Make these work like ad-block
@@ -133,7 +109,6 @@ const getManifestsDirByComponentType = (componentType) => {
 }
 
 const getNormalizedDATFileName = (datFileName) =>
-  datFileName === 'ABPFilterParserData' ||
   datFileName === 'httpse.leveldb' ||
   datFileName === 'ExtensionWhitelist' ||
   datFileName === 'Greaselion' ||
@@ -146,9 +121,6 @@ const getNormalizedDATFileName = (datFileName) =>
     : datFileName
 
 const getOriginalManifest = (componentType, datFileName) => {
-  if (componentType === 'ad-block-updater') {
-    return path.join(getManifestsDirByComponentType(componentType), datFileName, 'manifest.json')
-  }
   return path.join(getManifestsDirByComponentType(componentType), datFileName ? `${datFileName}-manifest.json` : 'manifest.json')
 }
 
@@ -157,15 +129,6 @@ const getDATFileListByComponentType = (componentType) => {
     case 'ethereum-remote-client':
     case 'wallet-data-files-updater':
       return ['']
-    case 'ad-block-updater':
-      return recursive(path.join('build', 'ad-block-updater'))
-        .filter(file => {
-          return (path.extname(file) === '.dat' && !file.includes('test-data'))
-        })
-        .reduce((acc, val) => {
-          acc.push(path.join(val))
-          return acc
-        }, [])
     case 'https-everywhere-updater':
       return path.join('node_modules', 'https-everywhere-builder', 'out', 'httpse.leveldb.zip').split()
     case 'local-data-files-updater':
@@ -199,10 +162,6 @@ const postNextVersionWork = (componentType, datFileName, key, publisherProofKey,
 const processDATFile = (binary, endpoint, region, componentType, key,
   publisherProofKey, localRun, datFile) => {
   let datFileName = getNormalizedDATFileName(path.parse(datFile).name)
-  if (componentType === 'ad-block-updater') {
-    // we need the last (build/ad-block-updater/<uuid>) folder name for ad-block-updater
-    datFileName = path.dirname(datFile).split(path.sep).pop()
-  }
 
   const originalManifest = getOriginalManifest(componentType, datFileName)
   const parsedManifest = util.parseManifest(originalManifest)
@@ -236,7 +195,7 @@ util.addCommonScriptOptions(
   commander
     .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
     .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
-    .option('-t, --type <type>', 'component extension type', /^(ad-block-updater|https-everywhere-updater|local-data-files-updater|ethereum-remote-client|wallet-data-files-updater|speedreader-updater)$/i, 'ad-block-updater')
+    .option('-t, --type <type>', 'component extension type', /^(https-everywhere-updater|local-data-files-updater|ethereum-remote-client|wallet-data-files-updater|speedreader-updater)$/i)
     .option('-l, --local-run', 'Runs updater job without connecting anywhere remotely'))
   .parse(process.argv)
 

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -103,32 +103,17 @@ const getDATFileVersionByComponentType = (componentType) => {
           'speedreader',
           'data',
           'default-manifest.json')).toString()).data_file_version
-    default:
-      throw new Error('Unrecognized component extension type: ' + componentType)
   }
 }
 
-const generateManifestFilesByComponentType = (componentType) => {
-  switch (componentType) {
-    case 'ethereum-remote-client':
-    case 'wallet-data-files-updater':
-      // Provides its own manifest file
-      break
-    case 'ad-block-updater':
-      break
-    case 'https-everywhere-updater':
-    case 'local-data-files-updater':
-      // TODO(emerick): Make these work like ad-block (i.e., update
-      // the corresponding repos with a script to generate the
-      // manifest and then call that script here)
-      break
-    case 'speedreader-updater':
-      // Provides its own manifest file
-      break
-    default:
-      throw new Error('Unrecognized component extension type: ' + componentType)
-  }
-}
+const validComponentTypes = [
+  'ethereum-remote-client',
+  'wallet-data-files-updater',
+  'ad-block-updater',
+  'https-everywhere-updater',
+  'local-data-files-updater',
+  'speedreader-updater'
+]
 
 const getManifestsDirByComponentType = (componentType) => {
   switch (componentType) {
@@ -144,8 +129,6 @@ const getManifestsDirByComponentType = (componentType) => {
       return path.join('manifests', componentType)
     case 'speedreader-updater':
       return path.join('node_modules', 'speedreader', 'data')
-    default:
-      throw new Error('Unrecognized component extension type: ' + componentType)
   }
 }
 
@@ -192,8 +175,6 @@ const getDATFileListByComponentType = (componentType) => {
     case 'speedreader-updater':
       return [path.join('node_modules', 'speedreader', 'data', 'speedreader-updater.dat'),
         path.join('node_modules', 'speedreader', 'data', 'content-stylesheet.css')]
-    default:
-      throw new Error('Unrecognized component extension type: ' + componentType)
   }
 }
 
@@ -239,7 +220,9 @@ const processDATFile = (binary, endpoint, region, componentType, key,
 }
 
 const processJob = (commander, keyParam) => {
-  generateManifestFilesByComponentType(commander.type)
+  if (!validComponentTypes.includes(commander.type)) {
+    throw new Error('Unrecognized component extension type: ' + commander.type)
+  }
   getDATFileListByComponentType(commander.type)
     .forEach(processDATFile.bind(null, commander.binary, commander.endpoint,
       commander.region, commander.type, keyParam,


### PR DESCRIPTION
Many of the other packaging scripts have their own logic in separate files. There is planned work on the adblock component packaging; separating this out into its own step will make it much easier to upgrade in the future.