### PR TITLE
Support plaintext adblock components

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -1,7 +1,7 @@
 const { uBlockResources } = require('adblock-rs')
 
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs').promises
 const request = require('request')
 
 const uBlockLocalRoot = 'submodules/uBlock'
@@ -37,30 +37,39 @@ const requestJSON = (url) => new Promise((resolve, reject) => {
 const getDefaultLists = requestJSON.bind(null, defaultListsUrl)
 const getRegionalLists = requestJSON.bind(null, regionalListsUrl)
 
+const lazyInit = (fn) => {
+  let prom
+  return () => {
+    prom = prom || fn()
+    return prom
+  }
+}
+
+const generateResources = lazyInit(() => new Promise((resolve, reject) => {
+  const resourceData = uBlockResources(
+    uBlockWebAccessibleResources,
+    uBlockRedirectEngine,
+    uBlockScriptlets
+  )
+  request.get(braveResourcesUrl, function (error, response, body) {
+    if (error) {
+      reject(new Error(`Request error: ${error}`))
+    }
+    if (response.statusCode !== 200) {
+      reject(new Error(`Error status code ${response.statusCode} returned for URL: ${braveResourcesUrl}`))
+    }
+    const braveResources = JSON.parse(body)
+    resourceData.push(...braveResources)
+    resolve(JSON.stringify(resourceData))
+  })
+}))
+
 /**
  * Returns a promise that generates a resources file from the uBlock Origin
  * repo hosted on GitHub
  */
-const generateResourcesFile = (outLocation) => {
-  return new Promise((resolve, reject) => {
-    const resourceData = uBlockResources(
-      uBlockWebAccessibleResources,
-      uBlockRedirectEngine,
-      uBlockScriptlets
-    )
-    request.get(braveResourcesUrl, function (error, response, body) {
-      if (error) {
-        reject(new Error(`Request error: ${error}`))
-      }
-      if (response.statusCode !== 200) {
-        reject(new Error(`Error status code ${response.statusCode} returned for URL: ${braveResourcesUrl}`))
-      }
-      const braveResources = JSON.parse(body)
-      resourceData.push(...braveResources)
-      fs.writeFileSync(outLocation, JSON.stringify(resourceData), 'utf8')
-      resolve()
-    })
-  })
+const generateResourcesFile = async (outLocation) => {
+  return fs.writeFile(outLocation, await generateResources(), 'utf8')
 }
 
 module.exports.generateResourcesFile = generateResourcesFile

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -14,6 +14,12 @@ const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resou
 const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
 const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
 
+const regionalCatalogComponentId = 'gkboaolpopklhgplhaaiboijnklogmbc'
+const regionalCatalogPubkey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsAnb1lw5UA1Ww4JIVE8PjKNlPogAdFoie+Aczk6ppQ4OrHANxz6oAk1xFuT2W3uhGOc3b/1ydIUMqOIdRFvMdEDUvKVeFyNAVXNSouFF7EBLEzcZfFtqoxeIbwEplVISUm+WUbsdVB9MInY3a4O3kNNuUijY7bmHzAqWMTrBfenw0Lqv38OfREXCiNq/+Jm/gt7FhyBd2oviXWEGp6asUwNavFnj8gQDGVvCf+dse8HRMJn00QH0MOypsZSWFZRmF08ybOu/jTiUo/TuIaHL1H8y9SR970LqsUMozu3ioSHtFh/IVgq7Nqy4TljaKsTE+3AdtjiOyHpW9ZaOkA7j2QIDAQAB'
+
+const resourcesComponentId = 'mfddibmblmbccpadfndgakiopmmhebop'
+const resourcesPubkey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7Qk6xtml8Siq8RD6cCbdJpArt0kMci82W/KYw3KR96y67MZAsKJa8rOV2WC1BIpW539Qgl5b5lMS04cjw+sSB7f2ZKM1WOqKNij24nvEKVubunP32u8tbjtzQk9VYNcM2MZMs330eqk7iuBRTvRViSMSeE3ymqp03HFpUGsdtjEBh1A5lroCg41eVnMn1I4GKPvuhT/Qc9Yem5gzXT/3n7H6vOGQ2dVBHz44mhgwtiDcsduh+Det6lCE2TgHOhHPdCewklgcoiNXP4zfXxfpPy1jbwb4w5KUnHSRelhfDnt+jI3jgHsD4IXdVNE5H5ZAnmcOJttbkRiT8kOVS0rJXwIDAQAB'
+
 /**
  * Returns a promise that which resolves with the body parsed as JSON
  *
@@ -72,6 +78,10 @@ const generateResourcesFile = async (outLocation) => {
   return fs.writeFile(outLocation, await generateResources(), 'utf8')
 }
 
+module.exports.regionalCatalogComponentId = regionalCatalogComponentId
+module.exports.regionalCatalogPubkey = regionalCatalogPubkey
+module.exports.resourcesComponentId = resourcesComponentId
+module.exports.resourcesPubkey = resourcesPubkey
 module.exports.generateResourcesFile = generateResourcesFile
 module.exports.getDefaultLists = getDefaultLists
 module.exports.getRegionalLists = getRegionalLists

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -80,7 +80,7 @@ const generateDataFileFromLists = (filterRuleData, outputDATFilename, outSubdir,
  * @param outputDATFilename the DAT filename to write to.
  * @return a Promise which resolves if successful or rejects if there's an error.
  */
-const generateDataFileFromURL = (listURL, format, langs, uuid, outputDATFilename) => {
+const generateDataFileFromURL = (listURL, format, langs, uuid, outputDATFilename, listTextComponent) => {
   return new Promise((resolve, reject) => {
     console.log(`${langs} ${listURL}...`)
     request.get(listURL, function (error, response, body) {
@@ -93,6 +93,10 @@ const generateDataFileFromURL = (listURL, format, langs, uuid, outputDATFilename
         return
       }
       generateDataFileFromLists([{ format, data: body }], outputDATFilename, uuid)
+      if (listTextComponent !== undefined) {
+        const outPath = getOutPath('list.txt', listTextComponent.component_id)
+        fs.writeFileSync(outPath, body)
+      }
       resolve()
     })
   })
@@ -113,7 +117,7 @@ const generateDataFilesForAllRegions = () => {
       resolve()
     }).then(Promise.all(regions.map(region =>
       generateDataFileFromURL(region.url,
-        region.format, region.langs, region.uuid, `rs-${region.uuid}.dat`)
+        region.format, region.langs, region.uuid, `rs-${region.uuid}.dat`, region.list_text_component)
     )))
   })
 }

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -42,8 +42,11 @@ const generateManifestFileForResources =
 
 const generateManifestFilesForAllRegions = async () => {
   const regionalLists = await getRegionalLists()
-  return Promise.all(regionalLists.map(region => {
-    return generateManifestFile.bind(null, region.title, region.base64_public_key, region.uuid)
+  return Promise.all(regionalLists.map(async region => {
+    await generateManifestFile(region.title, region.base64_public_key, region.uuid, region)
+    if (region.list_text_component) {
+      await generateManifestFile(region.title + ' (plaintext)', region.list_text_component.base64_public_key, region.list_text_component.component_id)
+    }
   }))
 }
 

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -5,7 +5,7 @@
 const fs = require('fs').promises
 const path = require('path')
 
-const { getRegionalLists } = require('../lib/adBlockRustUtils')
+const { getRegionalLists, regionalCatalogComponentId, regionalCatalogPubkey, resourcesComponentId, resourcesPubkey } = require('../lib/adBlockRustUtils')
 
 const outPath = path.join('build', 'ad-block-updater')
 
@@ -34,6 +34,12 @@ const generateManifestFile = async (name, base64PublicKey, uuid) => {
 const generateManifestFileForDefaultAdblock =
   generateManifestFile.bind(null, 'Default', defaultAdblockBase64PublicKey, 'default')  // eslint-disable-line
 
+const generateManifestFileForRegionalCatalog =
+  generateManifestFile.bind(null, 'Regional Catalog', regionalCatalogPubkey, regionalCatalogComponentId)  // eslint-disable-line
+
+const generateManifestFileForResources =
+  generateManifestFile.bind(null, 'Resources', resourcesPubkey, resourcesComponentId)  // eslint-disable-line
+
 const generateManifestFilesForAllRegions = async () => {
   const regionalLists = await getRegionalLists()
   return Promise.all(regionalLists.map(region => {
@@ -42,6 +48,8 @@ const generateManifestFilesForAllRegions = async () => {
 }
 
 generateManifestFileForDefaultAdblock()
+  .then(generateManifestFileForRegionalCatalog)
+  .then(generateManifestFileForResources)
   .then(generateManifestFilesForAllRegions)
   .then(() => {
     console.log('Thank you for updating the data files, don\'t forget to upload them too!')


### PR DESCRIPTION
Corresponds to https://github.com/brave/adblock-resources/pull/81 - these two changes can be merged in any order.

In addition to support for shipping plaintext adblock list formats in components, this adds a new component for the regional catalog and adblock resources. These change much less frequently than the rest of the adblock data, so the versions can be can be bumped independently to reduce bandwidth. This should also simplify logic in `brave-core` significantly.

The new components are addressed by component ID, rather than UUID, to reduce complexity in the future (https://github.com/brave/adblock-resources/issues/80).

New components:
- Regional Catalog `gkboaolpopklhgplhaaiboijnklogmbc`
- Resources `mfddibmblmbccpadfndgakiopmmhebop`
- Cookie List plaintext format `cdbbhgbmjhfnhnmgeddbliobbofkgdhe` (from https://github.com/brave/adblock-resources/pull/81)

PEMs have been uploaded to 1Password, and updated in CI.