### PR TITLE
Fixup for default adblock CRX packaging

### DIFF
--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -37,10 +37,10 @@ const postNextVersionWork = (componentSubdir, key, publisherProofKey,
   binary, localRun, version) => {
   const stagingDir = path.join('build', 'ad-block-updater', componentSubdir)
   const crxOutputDir = path.join('build', 'ad-block-updater')
-  const crxFile = path.join(crxOutputDir, componentSubdir === 'default' ? 'ad-block-updater.crx' : `ad-block-updater-${componentSubdir}.crx`)
+  const crxFile = path.join(crxOutputDir, `ad-block-updater-${componentSubdir}.crx`)
   stageFiles(version, stagingDir).then(() => {
     if (!localRun) {
-      const privateKeyFile = path.join(key, componentSubdir === 'default' ? 'ad-block-updater.pem' : `ad-block-updater-${componentSubdir}.pem`)
+      const privateKeyFile = path.join(key, `ad-block-updater-${componentSubdir}.pem`)
       util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
         stagingDir)
     }


### PR DESCRIPTION
Default component needs `ad-block-updater-default.pem`, not `ad-block-updater.pem`. Didn't catch this when testing locally since it was in a `if (!localRun) {...}` block.