### PR TITLE
Ship default adblock lists in plaintext format

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -14,6 +14,9 @@ const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resou
 const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
 const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
 
+const defaultPlaintextComponentId = 'iodkpdagapdfkphljnddpjlldadblomo'
+const defaultPlaintextPubkey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsD/B/MGdz0gh7WkcFARnZTBX9KAw2fuGeogijoI+fET38IK0L+P/trCT2NshqhRNmrDpLzV2+Dmes6PvkA+OdQkUV6VbChJG+baTfr3Oo5PdE0WxmP9Xh8XD7p85DQrk0jJilKuElxpK7Yq0JhcTSc3XNHeTwBVqCnHwWZZ+XysYQfjuDQ0MgQpS/s7U04OZ63NIPe/iCQm32stvS/pEya7KdBZXgRBQ59U6M1n1Ikkp3vfECShbBld6VrrmNrl59yKWlEPepJ9oqUc2Wf2Mq+SDNXROG554RnU4BnDJaNETTkDTZ0Pn+rmLmp1qY5Si0yGsfHkrv3FS3vdxVozOPQIDAQAB'
+
 const regionalCatalogComponentId = 'gkboaolpopklhgplhaaiboijnklogmbc'
 const regionalCatalogPubkey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsAnb1lw5UA1Ww4JIVE8PjKNlPogAdFoie+Aczk6ppQ4OrHANxz6oAk1xFuT2W3uhGOc3b/1ydIUMqOIdRFvMdEDUvKVeFyNAVXNSouFF7EBLEzcZfFtqoxeIbwEplVISUm+WUbsdVB9MInY3a4O3kNNuUijY7bmHzAqWMTrBfenw0Lqv38OfREXCiNq/+Jm/gt7FhyBd2oviXWEGp6asUwNavFnj8gQDGVvCf+dse8HRMJn00QH0MOypsZSWFZRmF08ybOu/jTiUo/TuIaHL1H8y9SR970LqsUMozu3ioSHtFh/IVgq7Nqy4TljaKsTE+3AdtjiOyHpW9ZaOkA7j2QIDAQAB'
 
@@ -78,6 +81,8 @@ const generateResourcesFile = async (outLocation) => {
   return fs.writeFile(outLocation, await generateResources(), 'utf8')
 }
 
+module.exports.defaultPlaintextComponentId = defaultPlaintextComponentId
+module.exports.defaultPlaintextPubkey = defaultPlaintextPubkey
 module.exports.regionalCatalogComponentId = regionalCatalogComponentId
 module.exports.regionalCatalogPubkey = regionalCatalogPubkey
 module.exports.resourcesComponentId = resourcesComponentId

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -5,7 +5,7 @@
 const fs = require('fs').promises
 const path = require('path')
 
-const { getRegionalLists, regionalCatalogComponentId, regionalCatalogPubkey, resourcesComponentId, resourcesPubkey } = require('../lib/adBlockRustUtils')
+const { getRegionalLists, defaultPlaintextComponentId, defaultPlaintextPubkey, regionalCatalogComponentId, regionalCatalogPubkey, resourcesComponentId, resourcesPubkey } = require('../lib/adBlockRustUtils')
 
 const outPath = path.join('build', 'ad-block-updater')
 
@@ -34,6 +34,9 @@ const generateManifestFile = async (name, base64PublicKey, uuid) => {
 const generateManifestFileForDefaultAdblock =
   generateManifestFile.bind(null, 'Default', defaultAdblockBase64PublicKey, 'default')  // eslint-disable-line
 
+const generateManifestFileForDefaultPlaintextAdblock =
+  generateManifestFile.bind(null, 'Default (plaintext)', defaultPlaintextPubkey, defaultPlaintextComponentId)  // eslint-disable-line
+
 const generateManifestFileForRegionalCatalog =
   generateManifestFile.bind(null, 'Regional Catalog', regionalCatalogPubkey, regionalCatalogComponentId)  // eslint-disable-line
 
@@ -51,6 +54,7 @@ const generateManifestFilesForAllRegions = async () => {
 }
 
 generateManifestFileForDefaultAdblock()
+  .then(generateManifestFileForDefaultPlaintextAdblock)
   .then(generateManifestFileForRegionalCatalog)
   .then(generateManifestFileForResources)
   .then(generateManifestFilesForAllRegions)

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -32,16 +32,16 @@ const generateManifestFile = async (name, base64PublicKey, uuid) => {
 }
 
 const generateManifestFileForDefaultAdblock =
-  generateManifestFile.bind(null, 'Default', defaultAdblockBase64PublicKey, 'default')  // eslint-disable-line
+  generateManifestFile.bind(null, 'Default', defaultAdblockBase64PublicKey, 'default')
 
 const generateManifestFileForDefaultPlaintextAdblock =
-  generateManifestFile.bind(null, 'Default (plaintext)', defaultPlaintextPubkey, defaultPlaintextComponentId)  // eslint-disable-line
+  generateManifestFile.bind(null, 'Default (plaintext)', defaultPlaintextPubkey, defaultPlaintextComponentId)
 
 const generateManifestFileForRegionalCatalog =
-  generateManifestFile.bind(null, 'Regional Catalog', regionalCatalogPubkey, regionalCatalogComponentId)  // eslint-disable-line
+  generateManifestFile.bind(null, 'Regional Catalog', regionalCatalogPubkey, regionalCatalogComponentId)
 
 const generateManifestFileForResources =
-  generateManifestFile.bind(null, 'Resources', resourcesPubkey, resourcesComponentId)  // eslint-disable-line
+  generateManifestFile.bind(null, 'Resources', resourcesPubkey, resourcesComponentId)
 
 const generateManifestFilesForAllRegions = async () => {
   const regionalLists = await getRegionalLists()


### PR DESCRIPTION
I generated a new component ID and pubkey for the plaintext format of our default adblock lists; the corresponding PEM has been uploaded to 1Password and is updated in Jenkins as well. This PR uses them to generate a new plaintext component version of the default lists.