### PR TITLE
Include JSON list updates in data-files-local-data-files build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ build
 
 # IDE-specific files
 *.swp
+
+# Lists for data-files-local-data-files
+brave-lists

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "adblock-lists": "github:brave/adblock-lists",
         "adblock-rs": "0.5.6",
         "ajv": "8.11.0",
         "aws-sdk": "2.1204.0",
@@ -912,11 +911,6 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
-    },
-    "node_modules/adblock-lists": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/adblock-lists.git#7df98a76975039abff3beaca8fb8213f5f77ac2b",
-      "license": "MPL-2.0"
     },
     "node_modules/adblock-rs": {
       "version": "0.5.6",
@@ -10208,10 +10202,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
-    },
-    "adblock-lists": {
-      "version": "git+ssh://git@github.com/brave/adblock-lists.git#7df98a76975039abff3beaca8fb8213f5f77ac2b",
-      "from": "adblock-lists@github:brave/adblock-lists"
     },
     "adblock-rs": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
   "dependencies": {
-    "adblock-lists": "github:brave/adblock-lists",
     "adblock-rs": "0.5.6",
     "ajv": "8.11.0",
     "aws-sdk": "2.1204.0",
@@ -36,7 +35,7 @@
     "data-files-ad-block-rust": "node scripts/generateAdBlockRustDataFiles.js",
     "data-files-https-everywhere": "npm run --prefix ./node_modules/https-everywhere-builder build",
     "data-files-extension-whitelist": "npm run --prefix ./node_modules/extension-whitelist data-files",
-    "data-files-local-data-files": "npm run data-files-extension-whitelist && npm install --prefix ./node_modules/brave-site-specific-scripts && npm run --prefix ./node_modules/brave-site-specific-scripts build",
+    "data-files-local-data-files": "npm run data-files-extension-whitelist && npm install --prefix ./node_modules/brave-site-specific-scripts && npm run --prefix ./node_modules/brave-site-specific-scripts build && mkdir -p brave-lists && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/clean-urls.json -O brave-lists/clean-urls.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/debounce.json -O brave-lists/debounce.json",
     "data-files-speedreader": "npm run --prefix ./node_modules/speedreader data-files",
     "download-ipfs-daemon": "node scripts/downloadIpfsDaemon.js",
     "generate-ad-block-manifests": "node scripts/generateManifestForRustAdblock.js",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -142,8 +142,8 @@ const getDATFileListByComponentType = (componentType) => {
       return path.join('node_modules', 'https-everywhere-builder', 'out', 'httpse.leveldb.zip').split()
     case 'local-data-files-updater':
       return [path.join('node_modules', 'extension-whitelist', 'data', 'ExtensionWhitelist.dat'),
-        path.join('node_modules', 'adblock-lists', 'brave-lists', 'debounce.json'),
-        path.join('node_modules', 'adblock-lists', 'brave-lists', 'clean-urls.json')].concat(
+        path.join('brave-lists', 'debounce.json'),
+        path.join('brave-lists', 'clean-urls.json')].concat(
         recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')))
     case 'speedreader-updater':
       return [path.join('node_modules', 'speedreader', 'data', 'speedreader-updater.dat'),


### PR DESCRIPTION
As per https://github.com/brave/brave-core-crx-packager/issues/467:

- the list downloads to override the `clean-urls` and `debounce` list versions from the outdated `adblock-lists` dependency were copied [from CI](https://github.com/brave/devops/blob/master/jenkins/jobs/extensions/dev/brave-core-ext-local-data-files-update-publish-dev.yml#L43-L45) into the `data-files-local-data-files` npm script
- the `adblock-lists` npm dependency was removed, since it's not used anywhere else and even those two files from it were being overridden

Once this is merged, we should be able to remove those special-cased download steps from CI.