### PR TITLE
Cache adblock component content hashes, avoid version bumps if they haven't changed

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -110,7 +110,7 @@ const uploadCRXFile = (endpoint, region, crxFile, componentId) => {
   })
 }
 
-const updateDBForCRXFile = (endpoint, region, crxFile, componentId) => {
+const updateDBForCRXFile = (endpoint, region, crxFile, componentId, contentHash) => {
   const unzipDir = path.join('build', 'unzip', path.parse(crxFile).name)
 
   mkdirp.sync(unzipDir)
@@ -122,7 +122,7 @@ const updateDBForCRXFile = (endpoint, region, crxFile, componentId) => {
     const hash = generateSHA256HashOfFile(crxFile)
     const name = data.name
 
-    return updateDynamoDB(endpoint, region, id, version, hash, name, false)
+    return updateDynamoDB(endpoint, region, id, version, hash, name, false, contentHash)
       .then(() => console.log(`Updated DB for ${crxFile}, ID: ${id}, hash: ${hash}, name: ${name}`))
       .catch((err) => {
         console.log(`Updating DB for ${crxFile} is failed.`)
@@ -294,7 +294,7 @@ const createTableIfNotExists = (endpoint, region) => {
     })
 }
 
-const getNextVersion = (endpoint, region, id) => {
+const getNextVersion = (endpoint, region, id, contentHash) => {
   const dynamodb = createDynamoDBInstance(endpoint, region)
   const params = {
     ExpressionAttributeValues: {
@@ -307,14 +307,19 @@ const getNextVersion = (endpoint, region, id) => {
   }
   return dynamodb.query(params).promise().then((data) => {
     if (data.Items.length === 1 && data.Items[0].Version.S !== '') {
-      return incrementVersion(data.Items[0].Version.S)
+      if (data.Items[0].ContentHash !== undefined && data.Items[0].ContentHash === contentHash) {
+        // return no next version if the content hash matches the last cached value
+        return undefined
+      } else {
+        return incrementVersion(data.Items[0].Version.S)
+      }
     } else {
       return '1.0.0'
     }
   })
 }
 
-const updateDynamoDB = (endpoint, region, id, version, hash, name, disabled) => {
+const updateDynamoDB = (endpoint, region, id, version, hash, name, disabled, contentHash) => {
   const dynamodb = createDynamoDBInstance(endpoint, region)
   const params = {
     Item: {
@@ -336,6 +341,11 @@ const updateDynamoDB = (endpoint, region, id, version, hash, name, disabled) => 
     },
     ReturnConsumedCapacity: 'TOTAL',
     TableName: DynamoDBTableName
+  }
+  if (contentHash !== undefined) {
+    params.Item.ContentHash = {
+      S: contentHash
+    }
   }
   return dynamodb.putItem(params).promise()
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -307,7 +307,7 @@ const getNextVersion = (endpoint, region, id, contentHash) => {
   }
   return dynamodb.query(params).promise().then((data) => {
     if (data.Items.length === 1 && data.Items[0].Version.S !== '') {
-      if (data.Items[0].ContentHash !== undefined && data.Items[0].ContentHash === contentHash) {
+      if (data.Items[0].ContentHash !== undefined && data.Items[0].ContentHash.S !== undefined && data.Items[0].ContentHash.S === contentHash) {
         // return no next version if the content hash matches the last cached value
         return undefined
       } else {

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -68,15 +68,18 @@ const processComponent = (binary, endpoint, region, keyDir,
   const parsedManifest = util.parseManifest(originalManifest)
   const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
-  let contentHash
+  let fileToHash
   if (id === regionalCatalogComponentId) {
-    const contentFile = path.join('build', 'ad-block-updater', componentSubdir, 'regional_catalog.json')
-    contentHash = util.generateSHA256HashOfFile(contentFile)
+    fileToHash = 'regional_catalog.json'
   } else if (id === resourcesComponentId) {
-    const contentFile = path.join('build', 'ad-block-updater', componentSubdir, 'resources.json')
-    contentHash = util.generateSHA256HashOfFile(contentFile)
+    fileToHash = 'resources.json'
   } else if (id.length === 32) {
-    const contentFile = path.join('build', 'ad-block-updater', componentSubdir, 'list.txt')
+    fileToHash = 'list.txt'
+  }
+
+  let contentHash
+  if (fileToHash !== undefined) {
+    const contentFile = path.join('build', 'ad-block-updater', componentSubdir, fileToHash)
     contentHash = util.generateSHA256HashOfFile(contentFile)
   }
 

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -41,6 +41,10 @@ const postNextVersionWork = (componentSubdir, key, publisherProofKey,
   const crxFile = path.join(crxOutputDir, `ad-block-updater-${componentSubdir}.crx`)
   const contentHashFile = path.join(crxOutputDir, `ad-block-updater-${componentSubdir}.contentHash`)
   stageFiles(version, stagingDir).then(() => {
+    // Remove any existing `.contentHash` file for determinism
+    if (fs.existsSync(contentHashFile)) {
+      fs.unlinkSync(contentHashFile)
+    }
     if (!localRun) {
       const privateKeyFile = path.join(key, `ad-block-updater-${componentSubdir}.pem`)
       util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -69,11 +69,11 @@ const processComponent = (binary, endpoint, region, keyDir,
   const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
   let fileToHash
-  if (id === regionalCatalogComponentId) {
+  if (componentSubdir === regionalCatalogComponentId) {
     fileToHash = 'regional_catalog.json'
-  } else if (id === resourcesComponentId) {
+  } else if (componentSubdir === resourcesComponentId) {
     fileToHash = 'resources.json'
-  } else if (id.length === 32) {
+  } else if (componentSubdir.length === 32) {
     fileToHash = 'list.txt'
   }
 

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -42,7 +42,7 @@ Promise.all(uploadJobs).then(() => {
   util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
     if (fs.lstatSync(crxParam).isDirectory()) {
       fs.readdirSync(crxParam).forEach(file => {
-        const filePath = path.join(crxParam, file)
+        const filePath = path.parse(path.join(crxParam, file))
         if (filePath.ext === '.crx') {
           const contentHashPath = path.resolve(filePath.dir, filePath.name + '.contentHash')
           let contentHash

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -47,7 +47,7 @@ Promise.all(uploadJobs).then(() => {
           const contentHashPath = path.resolve(filePath.dir, filePath.name + '.contentHash')
           let contentHash
           if (fs.existsSync(contentHashPath)) {
-            contentHash = fs.readFileSync(contentHashPath)
+            contentHash = fs.readFileSync(contentHashPath).toString()
           }
           util.updateDBForCRXFile(commander.endpoint, commander.region, path.join(crxParam, file), undefined, contentHash)
         }

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -42,8 +42,14 @@ Promise.all(uploadJobs).then(() => {
   util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
     if (fs.lstatSync(crxParam).isDirectory()) {
       fs.readdirSync(crxParam).forEach(file => {
-        if (path.parse(file).ext === '.crx') {
-          util.updateDBForCRXFile(commander.endpoint, commander.region, path.join(crxParam, file))
+        const filePath = path.join(crxParam, file)
+        if (filePath.ext === '.crx') {
+          const contentHashPath = path.resolve(filePath.dir, filePath.name + '.contentHash')
+          let contentHash
+          if (fs.existsSync(contentHashPath)) {
+            contentHash = fs.readFileSync(contentHashPath)
+          }
+          util.updateDBForCRXFile(commander.endpoint, commander.region, path.join(crxParam, file), undefined, contentHash)
         }
       })
     } else {


### PR DESCRIPTION
## Problem

The new independent components for adblock resources and the adblock regional catalog change very infrequently, but their versions are still incremented and new versions are sent to users daily. Some regional adblock lists are also updated less frequently than every day.

## Solution

If we can avoid re-packaging and shipping unchanged components to users who already have the most recent version, we can probably save a significant amount of CDN bandwidth.

## Basic approach

### Package step

Generate a hash of the content for a particular component. Save it to a file with the same name as the CRX, but with a `.contentHash` extension instead of `.crx`. This file can contain an arbitrary string; for these adblock components I've used a SHA256 hash of either `list.txt`, `resources.json`, or `regional_catalog.json`, depending on which type of component it is.

When checking DynamoDB for the previous version of the component, also check for the previous version's content hash. If it's identical to the one we just calculated, there's no point in creating and shipping out a new CRX with an incremented version, so it's skipped.

### Upload step
When uploading a CRX, check if a corresponding `.contentHash` file exists. If so, upload that file's contents to DynamoDB as well under the `ContentHash` attribute.