### PR TITLE
Add pr_body to submodule update action

### DIFF
--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -17,3 +17,4 @@ jobs:
           ref: master
           pr_branch: automated-submodule-update
           target_branch: master
+          pr_body: 'Review [brave/uBlock](https://github.com/brave/uBlock/pulls?q=is%3Apr+is%3Aclosed) for any recent format changes.'


### PR DESCRIPTION
As of https://github.com/mheap/submodule-sync-action/pull/5, we can now supply a description for the automated PRs.

I added a brief sentence that provides some context about why the change is requested, as well as a link to the corresponding changes that should be reviewed.