### PR TITLE
Update brave-site-specific-scripts version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,7 +1218,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#728f70140c9acda2e7d99b086b09c214f823682f",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#c421935819a914314cef87c0c1c3dc0e0ab7aa55",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -10122,7 +10122,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#728f70140c9acda2e7d99b086b09c214f823682f",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#c421935819a914314cef87c0c1c3dc0e0ab7aa55",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Updates brave-site-specific-scripts to latest version, which includes:

* https://github.com/brave/brave-site-specific-scripts/pull/90
* https://github.com/brave/brave-site-specific-scripts/pull/89

Changes have been tested by QA in the dev environment.