### PR TITLE
log when the key for packaging an adblock component is missing

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -31,6 +31,9 @@ const generateCRXFile = (binary, crxFile, privateKeyFile, publisherProofKey,
   if (!publisherProofKey) {
     throw new Error('Missing --publisher-proof-key <file>')
   }
+  if (!fs.existsSync(path.resolve(privateKeyFile))) {
+    throw new Error(`Private key file '${privateKeyFile}' is missing, was it uploaded?`)
+  }
   const args = [
     `--pack-extension=${path.resolve(inputDir)}`,
     `--pack-extension-key=${path.resolve(privateKeyFile)}`,


### PR DESCRIPTION
Need more context to debug a failure on the server