### PR TITLE
Update brave-site-specific-scripts version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,7 +1235,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#c421935819a914314cef87c0c1c3dc0e0ab7aa55",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#237196ce127c0febde2f98c68a5f58413857c001",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -10261,7 +10261,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#c421935819a914314cef87c0c1c3dc0e0ab7aa55",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#237196ce127c0febde2f98c68a5f58413857c001",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Updates brave-site-specific-scripts to latest version, which includes:
* https://github.com/brave/brave-site-specific-scripts/pull/92
* https://github.com/brave/brave-site-specific-scripts/pull/93

Changes have been tested by QA in the dev environment.