### PR TITLE
Remove brave-wallet-lists from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "ajv": "8.12.0",
         "aws-sdk": "2.1310.0",
         "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-        "brave-wallet-lists": "1.1.17",
         "ethereum-remote-client": "0.1.107",
         "extension-whitelist": "github:brave/extension-whitelist",
         "https-everywhere-builder": "github:brave/https-everywhere-builder",
@@ -1251,11 +1250,6 @@
       "dependencies": {
         "@types/chrome": "0.0.100"
       }
-    },
-    "node_modules/brave-wallet-lists": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.17.tgz",
-      "integrity": "sha512-mlt7HHxX6/KAsGtv/MIpwp/gdwJtNtm57Y1eheEXkoBVXr7cKDkquo39AUqC3bNqH988xI7jITrwQgVZ3SOYGQ=="
     },
     "node_modules/browser-level": {
       "version": "1.0.1",
@@ -10330,11 +10324,6 @@
       "requires": {
         "@types/chrome": "0.0.100"
       }
-    },
-    "brave-wallet-lists": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brave-wallet-lists/-/brave-wallet-lists-1.1.17.tgz",
-      "integrity": "sha512-mlt7HHxX6/KAsGtv/MIpwp/gdwJtNtm57Y1eheEXkoBVXr7cKDkquo39AUqC3bNqH988xI7jITrwQgVZ3SOYGQ=="
     },
     "browser-level": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "ajv": "8.12.0",
     "aws-sdk": "2.1310.0",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
-    "brave-wallet-lists": "1.1.17",
     "ethereum-remote-client": "0.1.107",
     "extension-whitelist": "github:brave/extension-whitelist",
     "https-everywhere-builder": "github:brave/https-everywhere-builder",


### PR DESCRIPTION
We install `brave-wallet-lists` directly in devops in order to keep the package up-to-date on every CI run.

See relevant devops PRs for further information: https://github.com/brave/devops/pull/9073 and https://github.com/brave/devops/pull/9072