### PR TITLE
Convert everything to ES Modules

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -1,7 +1,7 @@
-const { uBlockResources } = require('adblock-rs')
+import { uBlockResources } from 'adblock-rs'
 
-const path = require('path')
-const fs = require('fs').promises
+import path from 'path'
+import { promises as fs } from 'fs'
 
 const uBlockLocalRoot = 'submodules/uBlock'
 const uBlockWebAccessibleResources = path.join(uBlockLocalRoot, 'src/web_accessible_resources')
@@ -69,12 +69,14 @@ const generateResourcesFile = async (outLocation) => {
   return fs.writeFile(outLocation, await generateResources(), 'utf8')
 }
 
-module.exports.defaultPlaintextComponentId = defaultPlaintextComponentId
-module.exports.defaultPlaintextPubkey = defaultPlaintextPubkey
-module.exports.regionalCatalogComponentId = regionalCatalogComponentId
-module.exports.regionalCatalogPubkey = regionalCatalogPubkey
-module.exports.resourcesComponentId = resourcesComponentId
-module.exports.resourcesPubkey = resourcesPubkey
-module.exports.generateResourcesFile = generateResourcesFile
-module.exports.getDefaultLists = getDefaultLists
-module.exports.getRegionalLists = getRegionalLists
+export {
+  defaultPlaintextComponentId,
+  defaultPlaintextPubkey,
+  regionalCatalogComponentId,
+  regionalCatalogPubkey,
+  resourcesComponentId,
+  resourcesPubkey,
+  generateResourcesFile,
+  getDefaultLists,
+  getRegionalLists
+}

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const childProcess = require('child_process')
-const fs = require('fs')
-const path = require('path')
-const util = require('../lib/util')
-const { Readable } = require('stream')
-const { finished } = require('stream/promises')
+import childProcess from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import util from '../lib/util.js'
+import { Readable } from 'stream'
+import { finished } from 'stream/promises'
 
 const jsonSchemaVersion = 1
 
@@ -146,7 +146,7 @@ const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
   })
 }
 
-module.exports = {
+export default {
   generatePublicKeyAndID,
   prepareAssets
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const childProcess = require('child_process')
-const crypto = require('crypto')
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const s3 = require('s3-client')
-const unzip = require('unzip-crx-3')
-const AWS = require('aws-sdk')
-const { Readable } = require('stream')
-const { finished } = require('stream/promises')
+import childProcess from 'child_process'
+import crypto from 'crypto'
+import fs from 'fs'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import s3 from 's3-client'
+import unzip from 'unzip-crx-3'
+import AWS from 'aws-sdk'
+import { Readable } from 'stream'
+import { finished } from 'stream/promises'
 
 const DynamoDBTableName = 'Extensions'
 const FirstVersion = '1.0.0'
@@ -359,7 +359,7 @@ const addCommonScriptOptions = (command) => {
     .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
 }
 
-module.exports = {
+export default {
   createTableIfNotExists,
   downloadExtensionFromCWS,
   generateCRXFile,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "brave-core-crx-packager",
   "version": "1.0.0",
   "description": "Packages component and theme extensions used in the Brave browser",
+  "type": "module",
   "dependencies": {
     "adblock-rs": "0.7.7",
     "ajv": "8.12.0",

--- a/scripts/downloadIpfsDaemon.js
+++ b/scripts/downloadIpfsDaemon.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const crypto = require('crypto')
-const execSync = require('child_process').execSync
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const util = require('../lib/util')
+import crypto from 'crypto'
+import { execSync } from 'child_process'
+import fs from 'fs'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import util from '../lib/util.js'
 const ipfsVersion = '0.18.1'
 
 // Downloads the current (platform-specific) Ipfs Daemon from ipfs.io
@@ -81,6 +81,6 @@ downloadIpfsDaemon('linux', 'amd64')
 downloadIpfsDaemon('linux', 'arm64')
 downloadIpfsDaemon('win32', 'amd64')
 
-module.exports = {
+export {
   ipfsVersion
 }

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { Engine, FilterFormat, FilterSet, RuleTypes } = require('adblock-rs')
-const { generateResourcesFile, getDefaultLists, getRegionalLists, defaultPlaintextComponentId, resourcesComponentId, regionalCatalogComponentId } = require('../lib/adBlockRustUtils')
-const path = require('path')
-const fs = require('fs')
+import { Engine, FilterFormat, FilterSet, RuleTypes } from 'adblock-rs'
+import { generateResourcesFile, getDefaultLists, getRegionalLists, defaultPlaintextComponentId, resourcesComponentId, regionalCatalogComponentId } from '../lib/adBlockRustUtils.js'
+import path from 'path'
+import fs from 'fs'
 
 /**
  * Returns a promise that which resolves with the list data

--- a/scripts/generateBraveAdsResourcesComponentInputFiles.js
+++ b/scripts/generateBraveAdsResourcesComponentInputFiles.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const mkdirp = require('mkdirp')
-const fs = require('fs-extra')
-const commander = require('commander')
-const { Readable } = require('stream')
-const { finished } = require('stream/promises')
+import path from 'path'
+import mkdirp from 'mkdirp'
+import fs from 'fs-extra'
+import commander from 'commander'
+import { Readable } from 'stream'
+import { finished } from 'stream/promises'
 
 const getComponentList = () => {
   return [

--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const fs = require('fs').promises
-const path = require('path')
+import { promises as fs } from 'fs'
+import path from 'path'
 
-const { getRegionalLists, defaultPlaintextComponentId, defaultPlaintextPubkey, regionalCatalogComponentId, regionalCatalogPubkey, resourcesComponentId, resourcesPubkey } = require('../lib/adBlockRustUtils')
+import { getRegionalLists, defaultPlaintextComponentId, defaultPlaintextPubkey, regionalCatalogComponentId, regionalCatalogPubkey, resourcesComponentId, resourcesPubkey } from '../lib/adBlockRustUtils.js'
 
 const outPath = path.join('build', 'ad-block-updater')
 

--- a/scripts/generateNTPBackgroundImages.js
+++ b/scripts/generateNTPBackgroundImages.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const mkdirp = require('mkdirp')
-const fs = require('fs-extra')
-const commander = require('commander')
-const util = require('../lib/util')
-const { Readable } = require('stream')
-const { finished } = require('stream/promises')
+import path from 'path'
+import mkdirp from 'mkdirp'
+import fs from 'fs-extra'
+import commander from 'commander'
+import util from '../lib/util.js'
+import { Readable } from 'stream'
+import { finished } from 'stream/promises'
 
 const jsonSchemaVersion = 1
 

--- a/scripts/generateNTPSuperReferrer.js
+++ b/scripts/generateNTPSuperReferrer.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const mkdirp = require('mkdirp')
-const commander = require('commander')
-const util = require('../lib/util')
-const ntpUtil = require('../lib/ntpUtil')
+import path from 'path'
+import mkdirp from 'mkdirp'
+import commander from 'commander'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 
 async function generateNTPSuperReferrer (dataUrl, referrerName) {
   const rootResourceDir = path.join(path.resolve(), 'build', 'ntp-super-referrer', 'resources')

--- a/scripts/generateNTPSuperReferrerMappingTable.js
+++ b/scripts/generateNTPSuperReferrerMappingTable.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const mkdirp = require('mkdirp')
-const fs = require('fs-extra')
-const commander = require('commander')
-const util = require('../lib/util')
+import path from 'path'
+import mkdirp from 'mkdirp'
+import fs from 'fs-extra'
+import commander from 'commander'
+import util from '../lib/util.js'
 
 const jsonSchemaVersion = 1
 

--- a/scripts/generateYoutubedown.js
+++ b/scripts/generateYoutubedown.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const util = require('../lib/util')
+import commander from 'commander'
+import util from '../lib/util.js'
 
 util.installErrorHandlers()
 

--- a/scripts/importCWSComponents.js
+++ b/scripts/importCWSComponents.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const util = require('../lib/util')
+import commander from 'commander'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import util from '../lib/util.js'
 
 util.installErrorHandlers()
 

--- a/scripts/ntp-sponsored-images/generate.js
+++ b/scripts/ntp-sponsored-images/generate.js
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path')
-const mkdirp = require('mkdirp')
-const commander = require('commander')
-const util = require('../../lib/util')
-const ntpUtil = require('../../lib/ntpUtil')
-const params = require('./params')
+import path from 'path'
+import mkdirp from 'mkdirp'
+import commander from 'commander'
+import util from '../../lib/util.js'
+import ntpUtil from '../../lib/ntpUtil.js'
+import params from './params.js'
 
 // Downloads all current 'active' campaigns from S3 for each region/platform.
 // Can include or exclude specific regions, for performance optimization.

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -3,13 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../../lib/util')
-const params = require('./params')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../../lib/util.js'
+import params from './params.js'
 
 const stageFiles = (locale, version, outputDir) => {
   // Copy resources and manifest file to outputDir.

--- a/scripts/ntp-sponsored-images/params.js
+++ b/scripts/ntp-sponsored-images/params.js
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-const regionPlatformComponentMetadata = require('./region-platform-component-metadata')
+import regionPlatformComponentMetadata from './region-platform-component-metadata.js'
 
 /**
  *
@@ -63,4 +63,4 @@ function getTargetComponents (includesParamValue, excludesParamValue) {
   return targetComponents
 }
 
-module.exports.getTargetComponents = getTargetComponents
+export default { getTargetComponents }

--- a/scripts/ntp-sponsored-images/params.test.js
+++ b/scripts/ntp-sponsored-images/params.test.js
@@ -3,9 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
-const tap = require('tap')
-const params = require('./params')
-const allComponents = require('./region-platform-component-metadata')
+import tap from 'tap'
+import params from './params.js'
+import allComponents from './region-platform-component-metadata.js'
 
 tap.test('ntp getTargetComponentsFromArrays', (t) => {
   // blank

--- a/scripts/ntp-sponsored-images/region-platform-component-metadata.js
+++ b/scripts/ntp-sponsored-images/region-platform-component-metadata.js
@@ -8,7 +8,7 @@
  * @typedef {Object.<string, ComponentMetadata>} RegionPlatformComponentMetadata
  * @type {RegionPlatformComponentMetadata}
  */
-module.exports = {
+export default {
   'AF-desktop': {
     locale: 'AF',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3UQJgNrn5qHNcHU3OKhhK34FT0AN8V0+KJwBany7O3RbDh/JmZ28F18wAmq8r06XIFlxxm0vTA3YDtQ+kPzMCdk5fBIZKwVL7ikFEVV3vd3Opu26GRuJ+s9qEbgErHPGC0SHAse3FWhGKVw+sOI6bKOPUtRgmPJFeb8azE/qdVFvP8L0z3Ny0PSlu+wTb3klT0c3LVpA/2WSQLCfAZ8zvwCFDlsIoH/3oFRKgDpoWztIT15D1dfx/mAg8+j3KC8kjUBYBOHOjmTdjjQUrav4hcn39tIw83QovAEXEjy3aywSSrHP7Lg81gzJkR1EdufC+PCWPT6NQEUYSQPbNaxCtwIDAQAB',

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -6,12 +6,12 @@
 // Example usage:
 //  npm run package-ad-block -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/ad-block-updater-regional-component-keys
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
-const { regionalCatalogComponentId, resourcesComponentId } = require('../lib/adBlockRustUtils')
+import commander from 'commander'
+import fs from 'fs-extra'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
+import { regionalCatalogComponentId, resourcesComponentId } from '../lib/adBlockRustUtils.js'
 
 async function stageFiles (version, outputDir) {
   // ad-block components are in the correct folder

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
 
 const getComponentDataList = () => {
   return [

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -5,13 +5,13 @@
 // Example usage:
 //  npm run package-local-data-files -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/local-data-files-updater.pem
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const recursive = require('recursive-readdir-sync')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import recursive from 'recursive-readdir-sync'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
 
 async function stageFiles (componentType, datFile, version, outputDir) {
   let datFileName

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -5,12 +5,12 @@
 // Example usage:
 // npm run package-ipfs-daemon -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir
 
-const commander = require('commander')
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
+import commander from 'commander'
+import fs from 'fs'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
 const ipfsVersion = '0.18.1'
 
 const getIpfsDaemonPath = (os, arch) => {

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
-const ntpUtil = require('../lib/ntpUtil')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 
 const stageFiles = (version, outputDir) => {
   // Copy resources and manifest file to outputDir.

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
-const ntpUtil = require('../lib/ntpUtil')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 
 const stageFiles = (superReferrerName, version, outputDir) => {
   // Copy resources and manifest file to outputDir.

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
-const ntpUtil = require('../lib/ntpUtil')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 
 const stageFiles = (version, outputDir) => {
   // Copy mapping table and manifest file to outputDir.

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -5,14 +5,14 @@
 // Example usage:
 // npm run package-tor-client -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir
 
-const commander = require('commander')
-const crypto = require('crypto')
-const execSync = require('child_process').execSync
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
+import commander from 'commander'
+import crypto from 'crypto'
+import { execSync } from 'child_process'
+import fs from 'fs'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
 
 // Downloads the current (platform-specific) Tor client from S3
 const downloadTorClient = (platform) => {

--- a/scripts/packageTorPluggableTransports.js
+++ b/scripts/packageTorPluggableTransports.js
@@ -5,13 +5,13 @@
 // Example usage:
 // npm run package-tor-pluggable-transports -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --keys-directory path/to/key/dir
 
-const commander = require('commander')
-const execSync = require('child_process').execSync
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
+import commander from 'commander'
+import { execSync } from 'child_process'
+import fs from 'fs'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
 
 const TOR_PLUGGABLE_TRANSPORTS_UPDATER = 'tor-pluggable-transports-updater'
 

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs-extra')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const replace = require('replace-in-file')
-const util = require('../lib/util')
-const ntpUtil = require('../lib/ntpUtil')
+import commander from 'commander'
+import fs from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+import replace from 'replace-in-file'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 
 /*
   NOTE: For historical reason, this is named "Youtubedown" component, but

--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const commander = require('commander')
-const fs = require('fs')
-const path = require('path')
-const util = require('../lib/util')
+import commander from 'commander'
+import fs from 'fs'
+import path from 'path'
+import util from '../lib/util.js'
 
 util.installErrorHandlers()
 

--- a/test/generateResourcesFile.js
+++ b/test/generateResourcesFile.js
@@ -1,8 +1,8 @@
-const tap = require('tap')
-const tmp = require('tmp')
-const fs = require('fs')
+import tap from 'tap'
+import tmp from 'tmp'
+import fs from 'fs'
 
-const { generateResourcesFile } = require('../lib/adBlockRustUtils')
+import { generateResourcesFile } from '../lib/adBlockRustUtils.js'
 
 tap.test('generateResourcesFile', (t) => {
   const tmpfile = tmp.fileSync({ discardDescriptor: true })


### PR DESCRIPTION
Will be required for importing the [new scriptlets format](https://github.com/gorhill/uBlock/commit/18a84d2819d49444fc31c5350677ecc5b2ec73c6) from uBlock Origin, i.e.:

`lib/adBlockRustUtils.js`
```js
const { builtinScriptlets } = await import('../submodules/uBlock/assets/resources/scriptlets.js');
```

I've done `npm run test` and ran through the adblock-specific scripts, but haven't tested the others - help would be appreciated there.