### PR TITLE
Update code to support new uBlock Origin scriptlets format

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -47,14 +47,62 @@ const lazyInit = (fn) => {
   }
 }
 
+// Wraps new template scriptlets with the older "numbered template arg" format and any required dependency code
+const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
+  const args = ['{{1}}', '{{2}}', '{{3}}', '{{4}}', '{{5}}', '{{6}}', '{{7}}', '{{8}}', '{{9}}'];
+  let last_arg_index = 0;
+  for (const arg_index in args) {
+    if (args[arg_index] === '{{' + (Number(arg_index) + 1) + '}}') {
+      break;
+    }
+    last_arg_index += 1;
+  }
+  ${dependencyPrelude}
+  (${fnString})(...args.slice(0, last_arg_index))
+}`
+
 const generateResources = lazyInit(async () => {
+  const { builtinScriptlets } = await import(path.join('..', uBlockScriptlets).toString())
+
+  const dependencyFns = builtinScriptlets.filter(s => s.name.endsWith('.fn'))
+  // Assumption: dependency functions don't have any dependencies themselves
+  if (!dependencyFns.every(f => f.dependencies === undefined)) {
+    throw new Error('Recursive dependencies detected')
+  }
+  const dependencyMap = dependencyFns.reduce((map, entry) => {
+    map[entry.name] = entry
+    return map
+  }, {})
+
+  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn')).map(s => {
+    // Bundle dependencies wherever needed. This causes some small duplication but makes each scriptlet fully self-contained.
+    let dependencyPrelude = ''
+    if (s.dependencies !== undefined) {
+      for (const dep of s.dependencies) {
+        const thisDepCode = dependencyMap[dep].fn.toString()
+        if (thisDepCode === undefined) {
+          throw new Error(`Couldn't find dependency ${dep}`)
+        }
+        dependencyPrelude += thisDepCode + '\n'
+      }
+    }
+    const content = Buffer.from(wrapScriptletArgFormat(s.fn.toString(), dependencyPrelude)).toString('base64')
+    return {
+      name: s.name,
+      aliases: s.aliases ?? [],
+      kind: { mime: 'application/javascript' },
+      content
+    }
+  })
+
   const resourceData = uBlockResources(
     uBlockWebAccessibleResources,
-    uBlockRedirectEngine,
-    uBlockScriptlets
+    uBlockRedirectEngine
   )
+
   const braveResources = await requestJSON(braveResourcesUrl)
   resourceData.push(...braveResources)
+  resourceData.push(...transformedUboBuiltins)
   return JSON.stringify(resourceData)
 })
 

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -65,26 +65,29 @@ const generateResources = lazyInit(async () => {
   const { builtinScriptlets } = await import(path.join('..', uBlockScriptlets).toString())
 
   const dependencyFns = builtinScriptlets.filter(s => s.name.endsWith('.fn'))
-  // Assumption: dependency functions don't have any dependencies themselves
-  if (!dependencyFns.every(f => f.dependencies === undefined)) {
-    throw new Error('Recursive dependencies detected')
-  }
   const dependencyMap = dependencyFns.reduce((map, entry) => {
     map[entry.name] = entry
     return map
   }, {})
 
-  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn')).map(s => {
+  // ignore "trusted" scriptlets and scriptlets with execution world requirements for now
+  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust && s.world === undefined).map(s => {
     // Bundle dependencies wherever needed. This causes some small duplication but makes each scriptlet fully self-contained.
     let dependencyPrelude = ''
-    if (s.dependencies !== undefined) {
-      for (const dep of s.dependencies) {
-        const thisDepCode = dependencyMap[dep].fn.toString()
-        if (thisDepCode === undefined) {
-          throw new Error(`Couldn't find dependency ${dep}`)
+    const requiredDependencies = s.dependencies ?? []
+    for (const dep of requiredDependencies) {
+      for (const recursiveDep of dependencyMap[dep].dependencies ?? []) {
+        if (!requiredDependencies.includes(recursiveDep)) {
+          requiredDependencies.push(recursiveDep)
         }
-        dependencyPrelude += thisDepCode + '\n'
       }
+    }
+    for (const dep of requiredDependencies.reverse()) {
+      const thisDepCode = dependencyMap[dep].fn.toString()
+      if (thisDepCode === undefined) {
+        throw new Error(`Couldn't find dependency ${dep}`)
+      }
+      dependencyPrelude += thisDepCode + '\n'
     }
     const content = Buffer.from(wrapScriptletArgFormat(s.fn.toString(), dependencyPrelude)).toString('base64')
     return {

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -70,8 +70,8 @@ const generateResources = lazyInit(async () => {
     return map
   }, {})
 
-  // ignore "trusted" scriptlets and scriptlets with execution world requirements for now
-  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust && s.world === undefined).map(s => {
+  // ignore "trusted" scriptlets for now
+  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust).map(s => {
     // Bundle dependencies wherever needed. This causes some small duplication but makes each scriptlet fully self-contained.
     let dependencyPrelude = ''
     const requiredDependencies = s.dependencies ?? []


### PR DESCRIPTION
Replaces #595.

Requires:
- `brave-core` https://github.com/brave/brave-core/pull/17858 (uplifted to Release 1.50.x). 
- `brave-ios` https://github.com/brave/brave-ios/pull/7195 (merged to 1.50.x).

To summarize the changes:
- some of the scriptlets now rely on a `scriptletGlobals` object which must be shared between all the scriptlets in each page with injections (https://github.com/brave/brave-browser/issues/29435, related to https://github.com/gorhill/uBlock/commit/5c9c87e485308cb2dc6da102a0e20d8fce84124e)
- some scriptlets have dependencies. To handle this for now, I'm bundling all dependencies with the scriptlets that need them, even if it might result in some duplicated code in each page for multiple injections (related to https://github.com/gorhill/uBlock/commit/236fb3ad59ecf3e01066004fbe86d17bf2d00808)
- the original `{{1}}`, `{{2}}`, etc. strings for template placeholders have been removed. I added them back into the wrapper format and pass all of them (up to the first unmodified one) to the inner scriptlet code. (related to https://github.com/gorhill/uBlock/commit/18a84d2819d49444fc31c5350677ecc5b2ec73c6)


@pes10k could you review the approach here to verify that the wrapped format is good to inject into pages?