### PR TITLE
Retry failed requests

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -32,7 +32,7 @@ const requestJSON = (url) => {
     }
     return response.json()
   }).catch(error => {
-    throw new Error(`Error when fetching ${url}: ${error.cause}`)
+    throw new Error(`Error when fetching ${url}: ${error.message}`)
   })
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,6 +16,44 @@ import { finished } from 'stream/promises'
 const DynamoDBTableName = 'Extensions'
 const FirstVersion = '1.0.0'
 
+/**
+ * Returns a promise that resolves with the URL's body text data.
+ * The request will be retried several times if necessary.
+ *
+ * @param listURL The URL of the list to fetch
+ * @return a promise that resolves with the content of the list or rejects with an error message.
+ */
+const fetchTextFromURL = (listURL) => {
+  const attempt = () => fetch(listURL).then(response => {
+    if (response.status !== 200) {
+      throw new Error(`Error status ${response.status} ${response.statusText} returned for URL: ${listURL}`)
+    }
+    return response.text()
+  }).catch(error => {
+    throw new Error(`Error when fetching ${listURL}: ${error.message}`)
+  })
+
+  // Introduces a delayed rejection into a promise chain so that request retries can be caught in a loop until a request succeeds
+  const delayReject = (ms) => {
+    return (reason) => new Promise((_resolve, reject) => setTimeout(() => {
+      console.log(`Spurious error: ${reason.message}`)
+      console.log('  (retrying...)')
+      reject(reason)
+    }, ms))
+  }
+
+  const maxAttempts = 5
+  const delayMs = 3000
+
+  let p = Promise.reject(new Error())
+
+  for (let i = 0; i < maxAttempts; i++) {
+    p = p.catch(attempt).catch(delayReject(delayMs))
+  }
+
+  return p
+}
+
 const downloadExtensionFromCWS = async (componentId, chromiumVersion, outputPath) => {
   const url = `https://clients2.google.com/service/update2/crx?response=redirect&prodversion=${chromiumVersion}&acceptformat=crx3&x=id%3D${componentId}%26uc`
   const response = await fetch(url)
@@ -360,6 +398,7 @@ const addCommonScriptOptions = (command) => {
 }
 
 export default {
+  fetchTextFromURL,
   createTableIfNotExists,
   downloadExtensionFromCWS,
   generateCRXFile,

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -4,45 +4,9 @@
 
 import { Engine, FilterFormat, FilterSet, RuleTypes } from 'adblock-rs'
 import { generateResourcesFile, getDefaultLists, getRegionalLists, resourcesComponentId, regionalCatalogComponentId } from '../lib/adBlockRustUtils.js'
+import util from '../lib/util.js'
 import path from 'path'
 import fs from 'fs'
-
-/**
- * Returns a promise that which resolves with the list data
- *
- * @param listURL The URL of the list to fetch
- * @return a promise that resolves with the content of the list or rejects with an error message.
- */
-const getListBufferFromURL = (listURL) => {
-  const attempt = () => fetch(listURL).then(response => {
-    if (response.status !== 200) {
-      throw new Error(`Error status ${response.status} ${response.statusText} returned for URL: ${listURL}`)
-    }
-    return response.text()
-  }).catch(error => {
-    throw new Error(`Error when fetching ${listURL}: ${error.message}`)
-  })
-
-  // Introduces a delayed rejection into a promise chain so that request retries can be caught in a loop until a request succeeds
-  const delayReject = (ms) => {
-    return (reason) => new Promise((_resolve, reject) => setTimeout(() => {
-      console.log(`Spurious error: ${reason.message}`)
-      console.log(`  (retrying...)`)
-      reject(reason)
-    }, ms))
-  }
-
-  const maxAttempts = 5
-  const delayMs = 3000
-
-  let p = Promise.reject()
-
-  for (let i = 0; i < maxAttempts; i++) {
-    p = p.catch(attempt).catch(delayReject(delayMs))
-  }
-
-  return p
-}
 
 /**
  * Obtains the output path to store a file given the specied name and subdir
@@ -123,7 +87,7 @@ const generateDataFilesForCatalogEntry = (entry, doIos = false) => {
   const promises = []
   lists.forEach((l) => {
     console.log(`${entry.langs} ${l.url}...`)
-    promises.push(getListBufferFromURL(l.url).then(data => ({ title: l.title || entry.title, format: l.format, data })))
+    promises.push(util.fetchTextFromURL(l.url).then(data => ({ title: l.title || entry.title, format: l.format, data })))
   })
   let p = Promise.all(promises)
   p = p.then((listBuffers) => {


### PR DESCRIPTION
This should help limit the number of times the `brave-core-ext-ad-block-update-publish` job needs to be re-run.