### PR TITLE
Release notes for Kubo 0.20.0

### DIFF
--- a/CHANGELOG-go-ipfs.md
+++ b/CHANGELOG-go-ipfs.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Updated kubo to 0.20.0, from 0.19.1 (14-June-2023)
+## Updated kubo to 0.20.0, from 0.19.1 (15-June-2023)
 - [brave-browser#30652](https://github.com/brave/brave-browser/issues/30652) - Update kubo to 0.20.0
 - For full changelog, see https://github.com/ipfs/kubo/releases/tag/v0.20.0
 

--- a/CHANGELOG-go-ipfs.md
+++ b/CHANGELOG-go-ipfs.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Updated kubo to 0.20.0, from 0.19.1 (14-June-2023)
+- [brave-browser#30652](https://github.com/brave/brave-browser/issues/30652) - Update kubo to 0.20.0
+- For full changelog, see https://github.com/ipfs/kubo/releases/tag/v0.20.0
+
 ## Updated kubo to 0.19.1, from 0.18.1 (26-April-2023)
 - [brave-browser#29556](https://github.com/brave/brave-browser/issues/29556) - Update kubo to 0.19.1
 - For full changelog, see https://github.com/ipfs/kubo/releases/tag/v0.19.1


### PR DESCRIPTION
Closes : https://github.com/brave/qa-resources/issues/525