### PR TITLE
remove en from packager script

### DIFF
--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -230,11 +230,6 @@ const getComponentDataList = () => {
       locale: 'iso_3166_1_vn',
       key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn7qnkDAbGtBoBl4wIMmu4n1T/VkJXh9EA8wRfbkMSTBe8y4SvOtAPCEi6PA08OlQZg1wZmSdjHlXb7z6Uze7DTXN1go9GYm08sqk2vdgceobNNKxebnitQKzfrQRZOsSG4R+whkC8X8CQnuNydIV3nH/DxEhgH11kqJhjoFg5wZzvSP8KmTv3JtW84W+n4pZHlbHqeQGx9xqnrJJ0f+IGb8uSRM1H1o3/08ZUvf417g6ci2MhLBSn4fTwfsiZqLLjPx8/z4zBm4MWQIBpqBy7vLGOU+6AGy0TWpWKtg9fsBuBcDiywskbHyGWuYkSOyQ4VKc+JIKRwC+lUnPcqcjYQIDAQAB',
       id: 'jcffalbkohmmfjmgkdcphlimplejkmon'
-    },
-    {
-      locale: 'iso_639_1_en',
-      key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp3999qnB5RBaRYj2VwIgbHUyPrfwXsFVn8apmCcT23UHO33cAGHDVKSKvmpXn1L+jBfThPjY9EtW5yA1+6tmC7iJIesJjWbM/G/JA9Btc6f58a0xuPa86goCM10/EocttsoheOzi7A4DUGqCAhBh2HwhzRWxmJnYURtYJz5jX+gLbE8m0mxHZLktKIBPVqw3CbKeWN5kU1Pppg+Wh/xdTxOXhwBo6MNWog+oZEzSSvJ5zY1/vfX0VIMVYiHyNFvyNf5Bdu7aK9PDj3iQs6s5Ru7ahAQg2RglbvI7Axr4eSgKaxg6k/n6h83ltWdAoZqwbC07U0NIb9MtXmZLU76+OwIDAQAB',
-      id: 'ocilmpijebaopmdifcomolmpigakocmo'
     }
   ]
 }


### PR DESCRIPTION
removes packaging of en-lang components since they are not being updated. this saves incrementing the version and forcing users to download the same (large) file on every ads resources jenkins run.

I tested against this job https://ci.brave.com/job/brave-core-ext-user-model-installer-publish-dev/295/
and pointed to staging components.

The client will download the last file, so no risk of users not having files.
```
*Nightly/Staging*
brianfung Library/Application Support/BraveSoftware $ jq . Brave-Browser-Nightly/ocilmpijebaopmdifcomolmpigakocmo/1.0.122/bvkgcaxyaitmhkbbqnqnqugrjeqzspxv | wc -l
  372373
brianfung Library/Application Support/BraveSoftware $ jq . Brave-Browser-Nightly/ocilmpijebaopmdifcomolmpigakocmo/1.0.122/emgmepnebbddgnkhfmhdhmjifkglkamo | wc -l
 1490627
 
*Release/Production*
brianfung Library/Application Support/BraveSoftware $ jq . Brave-Browser/ocilmpijebaopmdifcomolmpigakocmo/1.0.63/bvkgcaxyaitmhkbbqnqnqugrjeqzspxv | wc -l
  372373
brianfung Library/Application Support/BraveSoftware $ jq . Brave-Browser/ocilmpijebaopmdifcomolmpigakocmo/1.0.63/emgmepnebbddgnkhfmhdhmjifkglkamo | wc -l 
 1490627

```
@ptjames 