### PR TITLE
Temporary workaround for missing scriptlet dependency function

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -69,6 +69,8 @@ const generateResources = lazyInit(async () => {
     map[entry.name] = entry
     return map
   }, {})
+  // temporary (🤞) workaround for https://github.com/uBlockOrigin/uBlock-issues/issues/2742#issuecomment-1668594237
+  dependencyMap['get-extra-args-entries.fn'] = ({ fn: function () {} })
 
   // ignore "trusted" scriptlets for now
   const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust).map(s => {


### PR DESCRIPTION
uBO doesn't error out on missing dependency functions, but we do here. I can revisit that later if necessary, but in the meantime I'd prefer to keep the stricter validation.