### PR TITLE
Test that resources are valid JS

### DIFF
--- a/test/generateResourcesFile.js
+++ b/test/generateResourcesFile.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import tmp from 'tmp'
 import fs from 'fs'
+import { spawnSync } from 'child_process'
 
 import { generateResourcesFile } from '../lib/adBlockRustUtils.js'
 
@@ -12,5 +13,14 @@ test('generateResourcesFile', async (t) => {
     const resources = JSON.parse(filedata)
     assert.ok(Object.prototype.toString.call(resources) === '[object Array]')
     assert.ok(resources.length >= 10)
+    for (const r of resources) {
+      assert.ok(r.kind !== undefined)
+      assert.ok(r.kind.mime !== undefined)
+      if (r.kind.mime === 'application/javascript' || r.kind.mime === 'fn/javascript') {
+        const script = atob(r.content)
+        const subprocess = spawnSync('node', ['--check'], { input: script })
+        assert.ok(subprocess.status === 0, 'Resource ' + r.name + ' is not valid JS:\n' + subprocess.stderr.toString() + '\n' + script)
+      }
+    }
   })
 })


### PR DESCRIPTION
This makes sure that every resource in `resources.json` has valid JS syntax by passing it to `node --check`. Should prevent mistakes like the one in https://github.com/brave/brave-core-crx-packager/pull/662 from happening again in the future.