### PR TITLE
Update brave-site-specific-scripts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,7 +2452,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#237196ce127c0febde2f98c68a5f58413857c001",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#f0079aee82a4bbef217da90707208bd00f99766a",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -8103,7 +8103,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#237196ce127c0febde2f98c68a5f58413857c001",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#f0079aee82a4bbef217da90707208bd00f99766a",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Update brave-site-specific-scripts version for Greaselion release.

Related to https://github.com/brave/brave-browser/issues/32107