### PR TITLE
Remove temporary workaround for `get-extra-args-entries.fn`

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -69,8 +69,6 @@ const generateResources = lazyInit(async () => {
     map[entry.name] = entry
     return map
   }, {})
-  // temporary (🤞) workaround for https://github.com/uBlockOrigin/uBlock-issues/issues/2742#issuecomment-1668594237
-  dependencyMap['get-extra-args-entries.fn'] = ({ fn: function getExtraArgsEntries () {} })
 
   // ignore "trusted" scriptlets for now
   const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust).map(s => {


### PR DESCRIPTION
Fixed upstream in https://github.com/gorhill/uBlock/commit/8bf1ed954d87d2e73b67b4c84d7cdfdd64fdd51b