### PR TITLE
Populate resource permission field

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -80,8 +80,7 @@ const generateResources = lazyInit(async () => {
     return map
   }, {})
 
-  // ignore "trusted" scriptlets for now
-  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn') && !s.requiresTrust).map(s => {
+  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn')).map(s => {
     // Bundle dependencies wherever needed. This causes some small duplication but makes each scriptlet fully self-contained.
     let dependencyPrelude = ''
     const requiredDependencies = s.dependencies ?? []
@@ -100,11 +99,14 @@ const generateResources = lazyInit(async () => {
       dependencyPrelude += thisDepCode + '\n'
     }
     const content = Buffer.from(wrapScriptletArgFormat(s.fn.toString(), dependencyPrelude)).toString('base64')
+    // in Brave Browser, bit 0 (i.e. 1 << 0) signifies uBO resource permission.
+    const permission = s.requiresTrust ? 1 : 0
     return {
       name: s.name,
       aliases: s.aliases ?? [],
       kind: { mime: 'application/javascript' },
-      content
+      content,
+      permission
     }
   })
 


### PR DESCRIPTION
The `permission` field corresponds to the format from https://github.com/brave/adblock-rust/pull/300/commits/a7a385a76ba9d0457aa68df4ddcb152fd222d533