### PR TITLE
Support unified adblock catalog

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -10,8 +10,7 @@ const uBlockScriptlets = path.join(uBlockLocalRoot, 'assets/resources/scriptlets
 
 const braveResourcesUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/dist/resources.json'
 
-const defaultListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/default.json'
-const regionalListsUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/regional.json'
+const listCatalogUrl = 'https://raw.githubusercontent.com/brave/adblock-resources/master/filter_lists/list_catalog.json'
 
 const regionalCatalogComponentId = 'gkboaolpopklhgplhaaiboijnklogmbc'
 const regionalCatalogPubkey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsAnb1lw5UA1Ww4JIVE8PjKNlPogAdFoie+Aczk6ppQ4OrHANxz6oAk1xFuT2W3uhGOc3b/1ydIUMqOIdRFvMdEDUvKVeFyNAVXNSouFF7EBLEzcZfFtqoxeIbwEplVISUm+WUbsdVB9MInY3a4O3kNNuUijY7bmHzAqWMTrBfenw0Lqv38OfREXCiNq/+Jm/gt7FhyBd2oviXWEGp6asUwNavFnj8gQDGVvCf+dse8HRMJn00QH0MOypsZSWFZRmF08ybOu/jTiUo/TuIaHL1H8y9SR970LqsUMozu3ioSHtFh/IVgq7Nqy4TljaKsTE+3AdtjiOyHpW9ZaOkA7j2QIDAQAB'
@@ -36,9 +35,6 @@ const requestJSON = (url) => {
   })
 }
 
-const getDefaultLists = requestJSON.bind(null, defaultListsUrl)
-const getRegionalLists = requestJSON.bind(null, regionalListsUrl)
-
 const lazyInit = (fn) => {
   let prom
   return () => {
@@ -46,6 +42,20 @@ const lazyInit = (fn) => {
     return prom
   }
 }
+
+const getListCatalog = lazyInit(async () => {
+  return requestJSON(listCatalogUrl)
+})
+
+// Legacy logic requires a distinction between default and regional lists.
+// This can be removed once DAT support is no longer needed by iOS.
+const isDefaultList = entry => entry.default_enabled && entry.hidden
+const getDefaultLists = () => getListCatalog().then(catalog => {
+  return catalog.filter(isDefaultList)
+})
+const getRegionalLists = () => getListCatalog().then(catalog => {
+  return catalog.filter(entry => !isDefaultList(entry))
+})
 
 // Wraps new template scriptlets with the older "numbered template arg" format and any required dependency code
 const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
@@ -123,6 +133,7 @@ export {
   resourcesComponentId,
   resourcesPubkey,
   generateResourcesFile,
+  getListCatalog,
   getDefaultLists,
   getRegionalLists
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -386,6 +386,13 @@ const addCommonScriptOptions = (command) => {
     .option('-r, --region <region>', 'The AWS region to use', 'us-west-2')
 }
 
+const escapeStringForJSON = str => {
+  if (typeof str !== 'string') {
+    throw new Error('Not a string: ' + JSON.stringify(str))
+  }
+  return JSON.stringify(str).slice(1, -1)
+}
+
 export default {
   fetchTextFromURL,
   createTableIfNotExists,
@@ -398,5 +405,6 @@ export default {
   parseManifest,
   uploadCRXFile,
   updateDBForCRXFile,
-  addCommonScriptOptions
+  addCommonScriptOptions,
+  escapeStringForJSON
 }

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Engine, FilterFormat, FilterSet, RuleTypes } from 'adblock-rs'
-import { generateResourcesFile, getDefaultLists, getRegionalLists, resourcesComponentId, regionalCatalogComponentId } from '../lib/adBlockRustUtils.js'
+import { generateResourcesFile, getListCatalog, getDefaultLists, getRegionalLists, resourcesComponentId, regionalCatalogComponentId } from '../lib/adBlockRustUtils.js'
 import util from '../lib/util.js'
 import path from 'path'
 import fs from 'fs'
@@ -113,7 +113,11 @@ const generateDataFilesForAllRegions = () => {
       const catalogString = JSON.stringify(regions)
       fs.writeFileSync(getOutPath('regional_catalog.json', 'default'), catalogString)
       fs.writeFileSync(getOutPath('regional_catalog.json', regionalCatalogComponentId), catalogString)
-      resolve()
+      getListCatalog().then(listCatalog => {
+        const catalogString = JSON.stringify(listCatalog)
+        fs.writeFileSync(getOutPath('list_catalog.json', regionalCatalogComponentId), catalogString)
+        resolve()
+      })
     }).then(() => Promise.all(regions.map(region =>
       generateDataFilesForCatalogEntry(region)
     )))


### PR DESCRIPTION
Required for https://github.com/brave/brave-core/pull/19946
Depends on https://github.com/brave/adblock-resources/pull/130

Will update `listCatalogUrl` prior to merging - right now it points to the `unified-catalog` branch of `adblock-resources`.

`list_catalog.json` is added directly into the existing regional catalog component. `regional_catalog.json` is still generated from the contents of `list_catalog.json` and added there for backwards compatibility. It can be removed once most users have updated beyond the versions where `list_catalog.json` is supported.