### PR TITLE
Skip generating manifests for nonexistent directories

### DIFF
--- a/scripts/generateManifestForRustAdblock.js
+++ b/scripts/generateManifestForRustAdblock.js
@@ -21,6 +21,7 @@ const generateManifestFile = async (name, base64PublicKey, uuid) => {
 
   const filePath = path.join(outPath, uuid, 'manifest.json')
   return fs.writeFile(filePath, manifest)
+    .catch(e => console.warn('Skipped writing manifest for ' + name + ': ' + e.message))
 }
 
 const generateManifestFileForRegionalCatalog =


### PR DESCRIPTION
To solve the most recent errors on adblock publish due to https://adblock.ee