### PR TITLE
Deduplicate file staging logic

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -12,6 +12,7 @@ import tmp from 'tmp'
 import unzip from 'unzip-crx-3'
 import { DynamoDBClient, CreateTableCommand, ListTablesCommand, PutItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, HeadObjectCommand, PutObjectCommand, PutObjectTaggingCommand } from '@aws-sdk/client-s3'
+import replace from 'replace-in-file'
 import { Readable } from 'stream'
 import { finished, pipeline } from 'stream/promises'
 
@@ -571,6 +572,16 @@ const escapeStringForJSON = str => {
   return JSON.stringify(str).slice(1, -1)
 }
 
+const copyManifestWithVersion = (originalLocation, outputLocation, version) => {
+  const replaceOptions = {
+    files: outputLocation,
+    from: /0\.0\.0/,
+    to: version
+  }
+  fs.copyFileSync(originalLocation, outputLocation)
+  replace.sync(replaceOptions)
+}
+
 export default {
   fetchTextFromURL,
   createTableIfNotExists,
@@ -586,5 +597,6 @@ export default {
   uploadCRXFile,
   updateDBForCRXFile,
   addCommonScriptOptions,
-  escapeStringForJSON
+  escapeStringForJSON,
+  copyManifestWithVersion
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@
 
 import childProcess from 'child_process'
 import crypto from 'crypto'
-import fs from 'fs'
+import fs from 'fs-extra'
 import { readFile } from 'node:fs/promises'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
@@ -583,6 +583,34 @@ const copyManifestWithVersion = (originalLocation, outputDir, version) => {
   replace.sync(replaceOptions)
 }
 
+const stageDir = (resourceDir, manifestTemplateLocation, version, outputDir) => {
+  fs.copySync(resourceDir, outputDir)
+  copyManifestWithVersion(manifestTemplateLocation, outputDir, version)
+}
+
+const stageFiles = (files, version, outputDir) => {
+  mkdirp.sync(outputDir)
+
+  let hasManifest = false
+
+  for (let { path: inputPath, outputName } of files) {
+    if (outputName === undefined) {
+      outputName = path.parse(inputPath).base
+    }
+
+    if (outputName === 'manifest.json') {
+      copyManifestWithVersion(inputPath, outputDir, version)
+      hasManifest = true
+    } else {
+      fs.copyFileSync(inputPath, path.join(outputDir, outputName))
+    }
+  }
+
+  if (!hasManifest) {
+    throw new Error('Missing manifest.json in output files: ' + JSON.stringify(files))
+  }
+}
+
 export default {
   fetchTextFromURL,
   createTableIfNotExists,
@@ -599,5 +627,7 @@ export default {
   updateDBForCRXFile,
   addCommonScriptOptions,
   escapeStringForJSON,
-  copyManifestWithVersion
+  copyManifestWithVersion,
+  stageDir,
+  stageFiles
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -572,7 +572,8 @@ const escapeStringForJSON = str => {
   return JSON.stringify(str).slice(1, -1)
 }
 
-const copyManifestWithVersion = (originalLocation, outputLocation, version) => {
+const copyManifestWithVersion = (originalLocation, outputDir, version) => {
+  const outputLocation = path.join(outputDir, 'manifest.json')
   const replaceOptions = {
     files: outputLocation,
     from: /0\.0\.0/,

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -18,9 +18,8 @@ const stageFiles = (locale, version, outputDir) => {
   fs.copySync(resourceDir, outputDir)
 
   // Fix up the manifest version
-  const originalManifestPath = getManifestPath(locale)
-  const outputManifestPath = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifestPath, outputManifestPath, version)
+  const originalManifest = getManifestPath(locale)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const generateManifestFile = (regionPlatform, componentData) => {

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -11,15 +11,12 @@ import util from '../../lib/util.js'
 import params from './params.js'
 
 const stageFiles = (locale, version, outputDir) => {
-  // Copy resources and manifest file to outputDir.
-  // Copy resource files
-  const resourceDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources', locale, '/')
-  console.log('copy dir:', resourceDir, ' to:', outputDir)
-  fs.copySync(resourceDir, outputDir)
-
-  // Fix up the manifest version
-  const originalManifest = getManifestPath(locale)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  util.stageDir(
+    undefined,
+    path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources', locale, '/'),
+    getManifestPath(locale),
+    version,
+    outputDir)
 }
 
 const generateManifestFile = (regionPlatform, componentData) => {

--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -7,7 +7,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../../lib/util.js'
 import params from './params.js'
 
@@ -21,14 +20,7 @@ const stageFiles = (locale, version, outputDir) => {
   // Fix up the manifest version
   const originalManifestPath = getManifestPath(locale)
   const outputManifestPath = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifestPath, ' to: ', outputManifestPath)
-  const replaceOptions = {
-    files: outputManifestPath,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifestPath, outputManifestPath)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifestPath, outputManifestPath, version)
 }
 
 const generateManifestFile = (regionPlatform, componentData) => {

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -9,7 +9,6 @@
 import commander from 'commander'
 import fs from 'fs-extra'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 import { regionalCatalogComponentId, resourcesComponentId } from '../lib/adBlockRustUtils.js'
 
@@ -20,12 +19,7 @@ async function stageFiles (version, outputDir) {
   const resourceJsonPath = path.join('build', 'ad-block-updater', 'default', resourceFileName)
   const outputManifest = path.join(outputDir, 'manifest.json')
   const outputResourceJSON = path.join(outputDir, resourceFileName)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(outputManifest, outputManifest, version)
   // Only copy resources.json into components with a UUID. We will migrate to
   // using component IDs instead of UUIDs for directory names.
   // UUIDs are 36 characters, component IDs are 32.

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -17,9 +17,10 @@ async function stageFiles (version, outputDir) {
   // we don't need to stage the crx files
   const resourceFileName = 'resources.json'
   const resourceJsonPath = path.join('build', 'ad-block-updater', 'default', resourceFileName)
-  const outputManifest = path.join(outputDir, 'manifest.json')
   const outputResourceJSON = path.join(outputDir, resourceFileName)
-  util.copyManifestWithVersion(outputManifest, outputManifest, version)
+  const originalManifest = path.join(outputDir, 'manifest.json')
+  // note - in-place file replacement, unlike other components
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
   // Only copy resources.json into components with a UUID. We will migrate to
   // using component IDs instead of UUIDs for directory names.
   // UUIDs are 36 characters, component IDs are 32.

--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -13,19 +13,21 @@ import util from '../lib/util.js'
 import { regionalCatalogComponentId, resourcesComponentId } from '../lib/adBlockRustUtils.js'
 
 async function stageFiles (version, outputDir) {
-  // ad-block components are in the correct folder
-  // we don't need to stage the crx files
-  const resourceFileName = 'resources.json'
-  const resourceJsonPath = path.join('build', 'ad-block-updater', 'default', resourceFileName)
-  const outputResourceJSON = path.join(outputDir, resourceFileName)
+  // ad-block components are already written in the output directory
+  // so we don't need to stage anything
   const originalManifest = path.join(outputDir, 'manifest.json')
-  // note - in-place file replacement, unlike other components
+  // note - in-place manifest replacement, unlike other components
   util.copyManifestWithVersion(originalManifest, outputDir, version)
-  // Only copy resources.json into components with a UUID. We will migrate to
+  // Copy resources.json into components with a UUID. We will migrate to
   // using component IDs instead of UUIDs for directory names.
   // UUIDs are 36 characters, component IDs are 32.
-  if (path.basename(outputDir).length > 32 && resourceJsonPath !== outputResourceJSON) {
-    fs.copyFileSync(resourceJsonPath, outputResourceJSON)
+  if (path.basename(outputDir).length > 32) {
+    const resourceFileName = 'resources.json'
+    const resourceJsonPath = path.join('build', 'ad-block-updater', 'default', resourceFileName)
+    const outputResourceJSON = path.join(outputDir, resourceFileName)
+    if (resourceJsonPath !== outputResourceJSON) {
+      fs.copyFileSync(resourceJsonPath, outputResourceJSON)
+    }
   }
 }
 

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -242,8 +242,7 @@ const stageFiles = (locale, version, outputDir) => {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(locale)
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const generateManifestFile = (componentData) => {

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -234,15 +234,12 @@ const getComponentDataList = () => {
 }
 
 const stageFiles = (locale, version, outputDir) => {
-  // Copy resources and manifest file to outputDir.
-  // Copy resource files
-  const resourceDir = path.join(path.resolve(), 'build', 'user-model-installer', 'resources', locale, '/')
-  console.log('copy dir:', resourceDir, ' to:', outputDir)
-  fs.copySync(resourceDir, outputDir)
-
-  // Fix up the manifest version
-  const originalManifest = getOriginalManifest(locale)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  util.stageDir(
+    undefined,
+    path.join(path.resolve(), 'build', 'user-model-installer', 'resources', locale, '/'),
+    getOriginalManifest(locale),
+    version,
+    outputDir)
 }
 
 const generateManifestFile = (componentData) => {

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -6,7 +6,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 
 const getComponentDataList = () => {
@@ -244,14 +243,7 @@ const stageFiles = (locale, version, outputDir) => {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(locale)
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const generateManifestFile = (componentData) => {

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -44,8 +44,7 @@ async function stageFiles (componentType, datFile, version, outputDir) {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(componentType, datFileName)
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const componentNeedsStraightCopyFromUnpackedDir = (componentType) => {

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -10,7 +10,6 @@ import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
 import recursive from 'recursive-readdir-sync'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 
 async function stageFiles (componentType, datFile, version, outputDir) {
@@ -46,14 +45,7 @@ async function stageFiles (componentType, datFile, version, outputDir) {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(componentType, datFileName)
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const componentNeedsStraightCopyFromUnpackedDir = (componentType) => {

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -9,7 +9,6 @@ import commander from 'commander'
 import fs from 'fs'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 const ipfsVersion = '0.23.0'
 
@@ -49,18 +48,10 @@ const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
   const outputManifest = path.join(outputDir, 'manifest.json')
   const outputIpfsClient = path.join(outputDir, path.parse(ipfsDaemon).base)
 
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-
   mkdirp.sync(outputDir)
 
-  fs.copyFileSync(originalManifest, outputManifest)
   fs.copyFileSync(ipfsDaemon, outputIpfsClient)
-
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -7,7 +7,6 @@
 
 import commander from 'commander'
 import fs from 'fs'
-import { mkdirp } from 'mkdirp'
 import path from 'path'
 import util from '../lib/util.js'
 const ipfsVersion = '0.23.0'
@@ -44,13 +43,11 @@ const packageIpfsDaemon = (binary, endpoint, region, os, arch, key,
 }
 
 const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
-  const originalManifest = getOriginalManifest(platform)
-  const outputIpfsClient = path.join(outputDir, path.parse(ipfsDaemon).base)
-
-  mkdirp.sync(outputDir)
-
-  fs.copyFileSync(ipfsDaemon, outputIpfsClient)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  const files = [
+    { path: getOriginalManifest(platform), outputName: 'manifest.json' },
+    { path: ipfsDaemon }
+  ]
+  util.stageFiles(files, version, outputDir)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageIpfsDaemon.js
+++ b/scripts/packageIpfsDaemon.js
@@ -45,13 +45,12 @@ const packageIpfsDaemon = (binary, endpoint, region, os, arch, key,
 
 const stageFiles = (platform, ipfsDaemon, version, outputDir) => {
   const originalManifest = getOriginalManifest(platform)
-  const outputManifest = path.join(outputDir, 'manifest.json')
   const outputIpfsClient = path.join(outputDir, path.parse(ipfsDaemon).base)
 
   mkdirp.sync(outputDir)
 
   fs.copyFileSync(ipfsDaemon, outputIpfsClient)
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -6,7 +6,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
@@ -19,14 +18,7 @@ const stageFiles = (version, outputDir) => {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const generateManifestFile = (publicKey) => {

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -17,8 +17,7 @@ const stageFiles = (version, outputDir) => {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const generateManifestFile = (publicKey) => {

--- a/scripts/packageNTPBackgroundImagesComponent.js
+++ b/scripts/packageNTPBackgroundImagesComponent.js
@@ -9,16 +9,14 @@ import path from 'path'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
-const stageFiles = (version, outputDir) => {
-  // Copy resources and manifest file to outputDir.
-  const resourceDir = path.join(path.resolve(), 'build', 'ntp-background-images', 'resources')
-  console.log('copy dir:', resourceDir, ' to:', outputDir)
-  fs.copySync(resourceDir, outputDir)
-
-  // Fix up the manifest version
-  const originalManifest = getOriginalManifest()
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+const getOriginalManifest = () => {
+  return path.join(path.resolve(), 'build', 'ntp-background-images', 'ntp-background-images-manifest.json')
 }
+
+const stageFiles = util.stageDir.bind(
+  undefined,
+  path.join(path.resolve(), 'build', 'ntp-background-images', 'resources'),
+  getOriginalManifest())
 
 const generateManifestFile = (publicKey) => {
   const manifestFile = getOriginalManifest()
@@ -30,10 +28,6 @@ const generateManifestFile = (publicKey) => {
     version: '0.0.0'
   }
   fs.writeFileSync(manifestFile, JSON.stringify(manifestContent))
-}
-
-const getOriginalManifest = () => {
-  return path.join(path.resolve(), 'build', 'ntp-background-images', 'ntp-background-images-manifest.json')
 }
 
 const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -6,7 +6,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
@@ -20,14 +19,7 @@ const stageFiles = (superReferrerName, version, outputDir) => {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(superReferrerName)
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const generateManifestFile = (superReferrerName, publicKey) => {

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -18,8 +18,7 @@ const stageFiles = (superReferrerName, version, outputDir) => {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest(superReferrerName)
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const generateManifestFile = (superReferrerName, publicKey) => {

--- a/scripts/packageNTPSuperReferrerComponent.js
+++ b/scripts/packageNTPSuperReferrerComponent.js
@@ -10,15 +10,12 @@ import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
 const stageFiles = (superReferrerName, version, outputDir) => {
-  // Copy resources and manifest file to outputDir.
-  // Copy resource files
-  const resourceDir = path.join(path.resolve(), 'build', 'ntp-super-referrer', 'resources', superReferrerName, '/')
-  console.log('copy dir:', resourceDir, ' to:', outputDir)
-  fs.copySync(resourceDir, outputDir)
-
-  // Fix up the manifest version
-  const originalManifest = getOriginalManifest(superReferrerName)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  util.stageDir(
+    undefined,
+    path.join(path.resolve(), 'build', 'ntp-super-referrer', 'resources', superReferrerName, '/'),
+    getOriginalManifest(superReferrerName),
+    version,
+    outputDir)
 }
 
 const generateManifestFile = (superReferrerName, publicKey) => {

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -18,8 +18,7 @@ const stageFiles = (version, outputDir) => {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const generateManifestFile = (publicKey) => {

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -6,7 +6,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
@@ -20,14 +19,7 @@ const stageFiles = (version, outputDir) => {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const generateManifestFile = (publicKey) => {

--- a/scripts/packageNTPSuperReferrerMappingTableComponent.js
+++ b/scripts/packageNTPSuperReferrerMappingTableComponent.js
@@ -10,15 +10,11 @@ import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
 const stageFiles = (version, outputDir) => {
-  // Copy mapping table and manifest file to outputDir.
-  const mapFile = path.join(path.resolve(), 'build', 'ntp-super-referrer', 'resources', 'mapping-table', 'mapping-table.json')
-  const outputMapFile = path.join(outputDir, 'mapping-table.json')
-  console.log('copy ', mapFile, ' to:', outputMapFile)
-  fs.copyFileSync(mapFile, outputMapFile)
-
-  // Fix up the manifest version
-  const originalManifest = getOriginalManifest()
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  const files = [
+    { path: getOriginalManifest(), outputName: 'manifest.json' },
+    { path: path.join(path.resolve(), 'build', 'ntp-super-referrer', 'resources', 'mapping-table', 'mapping-table.json') }
+  ]
+  util.stageFiles(files, version, outputDir)
 }
 
 const generateManifestFile = (publicKey) => {

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -11,7 +11,6 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 
 // Downloads the current (platform-specific) Tor client from S3
@@ -94,19 +93,11 @@ const stageFiles = (platform, torClient, version, outputDir) => {
   const outputTorrc = path.join(outputDir, 'tor-torrc')
   const inputTorrc = path.join('resources', 'tor', 'torrc')
 
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-
   mkdirp.sync(outputDir)
 
-  fs.copyFileSync(originalManifest, outputManifest)
   fs.copyFileSync(torClient, outputTorClient)
   fs.copyFileSync(inputTorrc, outputTorrc)
-
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 // Does a hash comparison on a file against a given hash

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -88,7 +88,6 @@ const packageTorClient = (binary, endpoint, region, platform, key,
 
 const stageFiles = (platform, torClient, version, outputDir) => {
   const originalManifest = getOriginalManifest(platform)
-  const outputManifest = path.join(outputDir, 'manifest.json')
   const outputTorClient = path.join(outputDir, path.parse(torClient).base)
   const outputTorrc = path.join(outputDir, 'tor-torrc')
   const inputTorrc = path.join('resources', 'tor', 'torrc')
@@ -97,7 +96,7 @@ const stageFiles = (platform, torClient, version, outputDir) => {
 
   fs.copyFileSync(torClient, outputTorClient)
   fs.copyFileSync(inputTorrc, outputTorrc)
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 // Does a hash comparison on a file against a given hash

--- a/scripts/packageTorClient.js
+++ b/scripts/packageTorClient.js
@@ -87,16 +87,12 @@ const packageTorClient = (binary, endpoint, region, platform, key,
 }
 
 const stageFiles = (platform, torClient, version, outputDir) => {
-  const originalManifest = getOriginalManifest(platform)
-  const outputTorClient = path.join(outputDir, path.parse(torClient).base)
-  const outputTorrc = path.join(outputDir, 'tor-torrc')
-  const inputTorrc = path.join('resources', 'tor', 'torrc')
-
-  mkdirp.sync(outputDir)
-
-  fs.copyFileSync(torClient, outputTorClient)
-  fs.copyFileSync(inputTorrc, outputTorrc)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  const files = [
+    { path: getOriginalManifest(platform), outputName: 'manifest.json' },
+    { path: torClient },
+    { path: path.join('resources', 'tor', 'torrc'), outputName: 'tor-torrc' }
+  ]
+  util.stageFiles(files, version, outputDir)
 }
 
 // Does a hash comparison on a file against a given hash

--- a/scripts/packageTorPluggableTransports.js
+++ b/scripts/packageTorPluggableTransports.js
@@ -66,7 +66,6 @@ const packageTorPluggableTransports = (binary, endpoint, region, platform, key, 
 
 const stageFiles = (platform, snowflake, obfs4, version, outputDir) => {
   const originalManifest = getOriginalManifest(platform)
-  const outputManifest = path.join(outputDir, 'manifest.json')
   const outputSnowflake = path.join(outputDir, path.parse(snowflake).base)
   const outputObfs4 = path.join(outputDir, path.parse(obfs4).base)
 
@@ -74,7 +73,7 @@ const stageFiles = (platform, snowflake, obfs4, version, outputDir) => {
 
   fs.copyFileSync(snowflake, outputSnowflake)
   fs.copyFileSync(obfs4, outputObfs4)
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageTorPluggableTransports.js
+++ b/scripts/packageTorPluggableTransports.js
@@ -65,15 +65,12 @@ const packageTorPluggableTransports = (binary, endpoint, region, platform, key, 
 }
 
 const stageFiles = (platform, snowflake, obfs4, version, outputDir) => {
-  const originalManifest = getOriginalManifest(platform)
-  const outputSnowflake = path.join(outputDir, path.parse(snowflake).base)
-  const outputObfs4 = path.join(outputDir, path.parse(obfs4).base)
-
-  mkdirp.sync(outputDir)
-
-  fs.copyFileSync(snowflake, outputSnowflake)
-  fs.copyFileSync(obfs4, outputObfs4)
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
+  const files = [
+    { path: getOriginalManifest(platform), outputName: 'manifest.json' },
+    { path: snowflake },
+    { path: obfs4 }
+  ]
+  util.stageFiles(files, version, outputDir)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageTorPluggableTransports.js
+++ b/scripts/packageTorPluggableTransports.js
@@ -10,7 +10,6 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 
 const TOR_PLUGGABLE_TRANSPORTS_UPDATER = 'tor-pluggable-transports-updater'
@@ -71,19 +70,11 @@ const stageFiles = (platform, snowflake, obfs4, version, outputDir) => {
   const outputSnowflake = path.join(outputDir, path.parse(snowflake).base)
   const outputObfs4 = path.join(outputDir, path.parse(obfs4).base)
 
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-
   mkdirp.sync(outputDir)
 
-  fs.copyFileSync(originalManifest, outputManifest)
   fs.copyFileSync(snowflake, outputSnowflake)
   fs.copyFileSync(obfs4, outputObfs4)
-
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -13,20 +13,14 @@ import ntpUtil from '../lib/ntpUtil.js'
   NOTE: For historical reason, this is named "Youtubedown" component, but
   we're packaging 'brave/playlist-component'.
 */
-const stageFiles = (version, outputDir) => {
-  // Copy resources and manifest file to outputDir.
-  const resourceDir = path.join(path.resolve(), 'node_modules', 'playlist-component')
-  console.log('copy dir:', resourceDir, ' to:', outputDir)
-  fs.copySync(resourceDir, outputDir)
-
-  // Fix up the manifest version
-  const originalManifest = getOriginalManifest()
-  util.copyManifestWithVersion(originalManifest, outputDir, version)
-}
-
 const getOriginalManifest = () => {
   return path.join(path.resolve(), 'node_modules', 'playlist-component', 'manifest.json')
 }
+
+const stageFiles = util.stageDir.bind(
+  undefined,
+  path.join(path.resolve(), 'node_modules', 'playlist-component'),
+  getOriginalManifest())
 
 const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
   publisherProofKey) => {

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -21,8 +21,7 @@ const stageFiles = (version, outputDir) => {
 
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
-  const outputManifest = path.join(outputDir, 'manifest.json')
-  util.copyManifestWithVersion(originalManifest, outputManifest, version)
+  util.copyManifestWithVersion(originalManifest, outputDir, version)
 }
 
 const getOriginalManifest = () => {

--- a/scripts/packageYoutubedown.js
+++ b/scripts/packageYoutubedown.js
@@ -6,7 +6,6 @@ import commander from 'commander'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import replace from 'replace-in-file'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
@@ -23,14 +22,7 @@ const stageFiles = (version, outputDir) => {
   // Fix up the manifest version
   const originalManifest = getOriginalManifest()
   const outputManifest = path.join(outputDir, 'manifest.json')
-  console.log('copy manifest file: ', originalManifest, ' to: ', outputManifest)
-  const replaceOptions = {
-    files: outputManifest,
-    from: /0\.0\.0/,
-    to: version
-  }
-  fs.copyFileSync(originalManifest, outputManifest)
-  replace.sync(replaceOptions)
+  util.copyManifestWithVersion(originalManifest, outputManifest, version)
 }
 
 const getOriginalManifest = () => {


### PR DESCRIPTION
Incremental work towards https://github.com/brave/brave-core-crx-packager/issues/622.

This PR refactors duplicated logic across all packaging scripts to use common `stageFiles` and `stageDir` utilities, removing a net of almost 100 lines.

In the future I'd like to consolidate all components into using just one of these utilities, however I've left that for a followup as it requires deeper understanding of each component being packaged and cleanup of some legacy backwards-compatible code.