### PR TITLE
remove undefined argument from stageDir

### DIFF
--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -12,7 +12,6 @@ import params from './params.js'
 
 const stageFiles = (locale, version, outputDir) => {
   util.stageDir(
-    undefined,
     path.join(path.resolve(), 'build', 'ntp-sponsored-images', 'resources', locale, '/'),
     getManifestPath(locale),
     version,

--- a/scripts/packageBraveAdsResourcesComponent.js
+++ b/scripts/packageBraveAdsResourcesComponent.js
@@ -235,7 +235,6 @@ const getComponentDataList = () => {
 
 const stageFiles = (locale, version, outputDir) => {
   util.stageDir(
-    undefined,
     path.join(path.resolve(), 'build', 'user-model-installer', 'resources', locale, '/'),
     getOriginalManifest(locale),
     version,


### PR DESCRIPTION
Fixes an issue introduced in #740 

These two instances of `stageDir` aren't bound so there is no `this` argument to pass.