### PR TITLE
Split local-data-files-updater out of `packageComponent`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "package-tor-pluggable-transports": "node ./scripts/packageTorPluggableTransports",
     "package-ipfs-daemon": "node ./scripts/packageIpfsDaemon",
     "package-wallet-data-files": "node ./scripts/packageComponent --type wallet-data-files-updater",
-    "package-local-data-files": "node ./scripts/packageComponent --type local-data-files-updater",
+    "package-local-data-files": "node ./scripts/packageLocalDataFiles",
     "package-ntp-background-images": "node ./scripts/packageNTPBackgroundImagesComponent",
     "package-ntp-sponsored-images": "node ./scripts/ntp-sponsored-images/package",
     "package-ntp-super-referrer": "node scripts/packageNTPSuperReferrerComponent.js",

--- a/scripts/packageComponent.js
+++ b/scripts/packageComponent.js
@@ -3,160 +3,75 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Example usage:
-//  npm run package-local-data-files -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/local-data-files-updater.pem
+//  npm run package-ethereum-remote-client -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/ethereum-remote-client.pem
 
 import commander from 'commander'
 import fs from 'fs-extra'
-import { mkdirp } from 'mkdirp'
 import path from 'path'
-import recursive from 'recursive-readdir-sync'
 import util from '../lib/util.js'
 
-async function stageFiles (componentType, datFile, version, outputDir) {
-  if (componentNeedsStraightCopyFromUnpackedDir(componentType)) {
-    util.stageDir(getManifestsDirByComponentType(componentType), getOriginalManifest(componentType), version, outputDir)
-  } else {
-    const datFileVersion = getDATFileVersionByComponentType(componentType)
-    let outputDatDir = datFileVersion
-    if (componentType === 'local-data-files-updater') {
-      const index = datFile.indexOf('/dist/')
-      if (index !== -1) {
-        let baseDir = datFile.substring(index + '/dist/'.length)
-        baseDir = baseDir.substring(0, baseDir.lastIndexOf('/'))
-        outputDatDir = path.join(outputDatDir, baseDir)
-      }
-    }
-    const parsedDatFile = path.parse(datFile)
-    const datFileBase = parsedDatFile.base
-    mkdirp.sync(path.join(outputDir, outputDatDir))
-    const datFileName = getNormalizedDATFileName(parsedDatFile.name)
-    const files = [
-      { path: getOriginalManifest(componentType, datFileName), outputName: 'manifest.json' },
-      { path: datFile, outputName: path.join(outputDatDir, datFileBase) }
-    ]
-    util.stageFiles(files, version, outputDir)
-  }
+const stageFiles = (componentType, version, outputDir) => {
+  util.stageDir(getPackageDirByComponentType(componentType), getOriginalManifest(componentType), version, outputDir)
 
   if (componentType === 'wallet-data-files-updater') {
     fs.unlinkSync(path.join(outputDir, 'package.json'))
   }
 }
 
-const componentNeedsStraightCopyFromUnpackedDir = (componentType) => {
-  switch (componentType) {
-    case 'ethereum-remote-client':
-    case 'wallet-data-files-updater':
-      return true
-    default:
-      return false
-  }
-}
-
-const getDATFileVersionByComponentType = (componentType) => {
-  switch (componentType) {
-    case 'ethereum-remote-client':
-    case 'wallet-data-files-updater':
-      return '0'
-    case 'local-data-files-updater':
-      return '1'
-    default:
-      // shouldn't be possible to get here
-      return null
-  }
-}
-
 const validComponentTypes = [
   'ethereum-remote-client',
-  'wallet-data-files-updater',
-  'local-data-files-updater'
+  'wallet-data-files-updater'
 ]
 
-const getManifestsDirByComponentType = (componentType) => {
+const getPackageNameByComponentType = (componentType) => {
   switch (componentType) {
     case 'ethereum-remote-client':
-      return path.join('node_modules', 'ethereum-remote-client')
+      return componentType
     case 'wallet-data-files-updater':
-      return path.join('node_modules', 'brave-wallet-lists')
-    case 'local-data-files-updater':
-      // TODO(emerick): Make these work like ad-block (i.e., update
-      // the corresponding repos with a script to generate the
-      // manifest and then call that script here)
-      return path.join('manifests', componentType)
+      return 'brave-wallet-lists'
     default:
       // shouldn't be possible to get here
       return null
   }
 }
-
-const getNormalizedDATFileName = (datFileName) =>
-  datFileName === 'Greaselion' ||
-  datFileName === 'debounce' ||
-  datFileName === 'request-otr' ||
-  datFileName === 'clean-urls' ||
-  datFileName === 'https-upgrade-exceptions-list' ||
-  datFileName === 'localhost-permission-allow-list' ||
-  datFileName === 'messages' ||
-  datFileName.endsWith('.bundle')
-    ? 'default'
-    : datFileName
-
-const getOriginalManifest = (componentType, datFileName) => {
-  return path.join(getManifestsDirByComponentType(componentType), datFileName ? `${datFileName}-manifest.json` : 'manifest.json')
+const getPackageDirByComponentType = (componentType) => {
+  return path.join('node_modules', getPackageNameByComponentType(componentType))
 }
 
-const getDATFileListByComponentType = (componentType) => {
-  switch (componentType) {
-    case 'ethereum-remote-client':
-    case 'wallet-data-files-updater':
-      return ['']
-    case 'local-data-files-updater':
-      return [path.join('brave-lists', 'debounce.json'),
-        path.join('brave-lists', 'request-otr.json'),
-        path.join('brave-lists', 'clean-urls.json'),
-        path.join('brave-lists', 'https-upgrade-exceptions-list.txt'),
-        path.join('brave-lists', 'localhost-permission-allow-list.txt')
-      ].concat(
-        recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')))
-    default:
-      // shouldn't be possible to get here
-      return null
-  }
+const getOriginalManifest = (componentType) => {
+  return path.join(getPackageDirByComponentType(componentType), 'manifest.json')
 }
 
-const postNextVersionWork = (componentType, datFileName, key, publisherProofKey,
-  binary, localRun, datFile, version) => {
-  const stagingDir = path.join('build', componentType, datFileName)
-  const crxOutputDir = path.join('build', componentType)
-  const crxFile = path.join(crxOutputDir, datFileName ? `${componentType}-${datFileName}.crx` : `${componentType}.crx`)
+const postNextVersionWork = (componentType, key, publisherProofKey,
+  binary, localRun, version) => {
+  const stagingDir = path.join('build', componentType)
+  const crxFile = path.join(stagingDir, `${componentType}.crx`)
   let privateKeyFile = ''
   if (!localRun) {
-    privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, datFileName ? `${componentType}-${datFileName}.pem` : `${componentType}.pem`)
+    privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `${componentType}.pem`)
   }
-  stageFiles(componentType, datFile, version, stagingDir).then(() => {
-    if (!localRun) {
-      util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
-        stagingDir)
-    }
-    console.log(`Generated ${crxFile} with version number ${version}`)
-  })
+  stageFiles(componentType, version, stagingDir)
+  if (!localRun) {
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+      stagingDir)
+  }
+  console.log(`Generated ${crxFile} with version number ${version}`)
 }
 
 const processDATFile = (binary, endpoint, region, componentType, key,
-  publisherProofKey, localRun, datFile) => {
-  const datFileName = getNormalizedDATFileName(path.parse(datFile).name)
-
-  const originalManifest = getOriginalManifest(componentType, datFileName)
+  publisherProofKey, localRun) => {
+  const originalManifest = getOriginalManifest(componentType)
   const parsedManifest = util.parseManifest(originalManifest)
   const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
   if (!localRun) {
     util.getNextVersion(endpoint, region, id).then((version) => {
-      postNextVersionWork(componentType, datFileName, key, publisherProofKey,
-        binary, localRun, datFile, version)
+      postNextVersionWork(componentType, key, publisherProofKey,
+        binary, localRun, version)
     })
   } else {
-    postNextVersionWork(componentType, datFileName, key, publisherProofKey,
-      binary, localRun, datFile, '1.0.0')
+    postNextVersionWork(componentType, key, publisherProofKey,
+      binary, localRun, '1.0.0')
   }
 }
 
@@ -164,11 +79,10 @@ const processJob = (commander, keyParam) => {
   if (!validComponentTypes.includes(commander.type)) {
     throw new Error('Unrecognized component extension type: ' + commander.type)
   }
-  getDATFileListByComponentType(commander.type)
-    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint,
-      commander.region, commander.type, keyParam,
-      commander.publisherProofKey,
-      commander.localRun))
+  processDATFile(commander.binary, commander.endpoint,
+    commander.region, commander.type, keyParam,
+    commander.publisherProofKey,
+    commander.localRun)
 }
 
 util.installErrorHandlers()

--- a/scripts/packageLocalDataFiles.js
+++ b/scripts/packageLocalDataFiles.js
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+//  npm run package-local-data-files -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/local-data-files-updater.pem
+
+import commander from 'commander'
+import fs from 'fs-extra'
+import { mkdirp } from 'mkdirp'
+import path from 'path'
+import recursive from 'recursive-readdir-sync'
+import util from '../lib/util.js'
+
+const getOriginalManifest = () => {
+  return path.join('manifests', 'local-data-files-updater', 'default-manifest.json')
+}
+
+const stageFiles = (datFile, version, outputDir) => {
+  const datFileVersion = '1'
+  let outputDatDir = datFileVersion
+  const index = datFile.indexOf('/dist/')
+  if (index !== -1) {
+    let baseDir = datFile.substring(index + '/dist/'.length)
+    baseDir = baseDir.substring(0, baseDir.lastIndexOf('/'))
+    outputDatDir = path.join(outputDatDir, baseDir)
+  }
+  const parsedDatFile = path.parse(datFile)
+  const datFileBase = parsedDatFile.base
+  mkdirp.sync(path.join(outputDir, outputDatDir))
+  const files = [
+    { path: getOriginalManifest(), outputName: 'manifest.json' },
+    { path: datFile, outputName: path.join(outputDatDir, datFileBase) }
+  ]
+  util.stageFiles(files, version, outputDir)
+}
+
+const postNextVersionWork = (key, publisherProofKey, binary, localRun, datFile,
+  version) => {
+  const componentType = 'local-data-files-updater'
+  const datFileName = 'default'
+  const stagingDir = path.join('build', componentType, datFileName)
+  const crxOutputDir = path.join('build', componentType)
+  const crxFile = path.join(crxOutputDir, `${componentType}-${datFileName}.crx`)
+  let privateKeyFile = ''
+  if (!localRun) {
+    privateKeyFile = !fs.lstatSync(key).isDirectory() ? key : path.join(key, `${componentType}-${datFileName}.pem`)
+  }
+  stageFiles(datFile, version, stagingDir)
+  if (!localRun) {
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+      stagingDir)
+  }
+  console.log(`Generated ${crxFile} with version number ${version}`)
+}
+
+const processDATFile = (binary, endpoint, region, key, publisherProofKey,
+  localRun, datFile) => {
+  const originalManifest = getOriginalManifest()
+  const parsedManifest = util.parseManifest(originalManifest)
+  const id = util.getIDFromBase64PublicKey(parsedManifest.key)
+
+  if (!localRun) {
+    util.getNextVersion(endpoint, region, id).then((version) => {
+      postNextVersionWork(key, publisherProofKey,
+        binary, localRun, datFile, version)
+    })
+  } else {
+    postNextVersionWork(key, publisherProofKey,
+      binary, localRun, datFile, '1.0.0')
+  }
+}
+
+const processJob = (commander, keyParam) => {
+  const fileList = [
+    path.join('brave-lists', 'debounce.json'),
+    path.join('brave-lists', 'request-otr.json'),
+    path.join('brave-lists', 'clean-urls.json'),
+    path.join('brave-lists', 'https-upgrade-exceptions-list.txt'),
+    path.join('brave-lists', 'localhost-permission-allow-list.txt')
+  ].concat(
+    recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')))
+  fileList
+    .forEach(processDATFile.bind(null, commander.binary, commander.endpoint,
+      commander.region, keyParam, commander.publisherProofKey,
+      commander.localRun))
+}
+
+util.installErrorHandlers()
+
+util.addCommonScriptOptions(
+  commander
+    .option('-d, --keys-directory <dir>', 'directory containing private keys for signing crx files')
+    .option('-f, --key-file <file>', 'private key file for signing crx', 'key.pem')
+    .option('-l, --local-run', 'Runs updater job without connecting anywhere remotely'))
+  .parse(process.argv)
+
+let keyParam = ''
+
+if (!commander.localRun) {
+  if (fs.existsSync(commander.keyFile)) {
+    keyParam = commander.keyFile
+  } else if (fs.existsSync(commander.keysDirectory)) {
+    keyParam = commander.keysDirectory
+  } else {
+    throw new Error('Missing or invalid private key file/directory')
+  }
+}
+
+if (!commander.localRun) {
+  util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+    processJob(commander, keyParam)
+  })
+} else {
+  processJob(commander, keyParam)
+}

--- a/scripts/packageLocalDataFiles.js
+++ b/scripts/packageLocalDataFiles.js
@@ -18,31 +18,27 @@ const getOriginalManifest = () => {
 
 const stageFiles = (version, outputDir) => {
   const datFileVersion = '1'
-  const fileList = [
-    path.join('brave-lists', 'debounce.json'),
-    path.join('brave-lists', 'request-otr.json'),
-    path.join('brave-lists', 'clean-urls.json'),
-    path.join('brave-lists', 'https-upgrade-exceptions-list.txt'),
-    path.join('brave-lists', 'localhost-permission-allow-list.txt')
+  const files = [
+    { path: getOriginalManifest(), outputName: 'manifest.json' },
+    { path: path.join('brave-lists', 'debounce.json'), outputName: path.join(datFileVersion, 'debounce.json') },
+    { path: path.join('brave-lists', 'request-otr.json'), outputName: path.join(datFileVersion, 'request-otr.json') },
+    { path: path.join('brave-lists', 'clean-urls.json'), outputName: path.join(datFileVersion, 'clean-urls.json') },
+    { path: path.join('brave-lists', 'https-upgrade-exceptions-list.txt'), outputName: path.join(datFileVersion, 'https-upgrade-exceptions-list.txt') },
+    { path: path.join('brave-lists', 'localhost-permission-allow-list.txt'), outputName: path.join(datFileVersion, 'localhost-permission-allow-list.txt') }
   ].concat(
-    recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')))
-  fileList.forEach(datFile => {
-    let outputDatDir = datFileVersion
-    const index = datFile.indexOf('/dist/')
-    if (index !== -1) {
-      let baseDir = datFile.substring(index + '/dist/'.length)
+    recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')).map(f => {
+      let outputDatDir = datFileVersion
+      const index = f.indexOf('/dist/')
+      let baseDir = f.substring(index + '/dist/'.length)
       baseDir = baseDir.substring(0, baseDir.lastIndexOf('/'))
       outputDatDir = path.join(outputDatDir, baseDir)
-    }
-    const parsedDatFile = path.parse(datFile)
-    const datFileBase = parsedDatFile.base
-    mkdirp.sync(path.join(outputDir, outputDatDir))
-    const files = [
-      { path: getOriginalManifest(), outputName: 'manifest.json' },
-      { path: datFile, outputName: path.join(outputDatDir, datFileBase) }
-    ]
-    util.stageFiles(files, version, outputDir)
-  })
+      mkdirp.sync(path.join(outputDir, outputDatDir))
+      return {
+        path: f,
+        outputName: path.join(outputDatDir, path.parse(f).base)
+      }
+    }))
+  util.stageFiles(files, version, outputDir)
 }
 
 const postNextVersionWork = (key, publisherProofKey, binary, localRun, version) => {


### PR DESCRIPTION
close inspection of the diffs will reveal a nightmarishly twisted wreck of two completely unrelated logical concepts.

highlights:
- `getDATFileListByComponentType` returned a recursively traversed list of file paths + 5 other hardcoded ones for `local-data-files` jobs, but returned _a list of 1 empty string_ for the other jobs
- the `local-data-files` job produces _ONE_ component, yet the main entry point called `processDATFile` once per file above, with no one-off logic before or after
- for `local-data-files`, each invocation of `processDATFile` would reverse-engineer the location of the exact same manifest template file using `getNormalizedDATFileName`
- `getNormalizedDATFileName` chained together 8 conditions about hardcoded filename strings with no explanation of why or where they came from. Figuring that out requires auditing _every_ file in every component touched by this script.
- the empty string mentioned above was silently used in multiple contexts, including ternary conditions, string concatenation, _path concatenation_ (who knew `path.join('a', 'b', '')` returns `a/b`?), _path parsing_ (`path.parse('').name` is a great way to get a new empty string!)
- don't get me started on `stageFiles`, which I already had to partially address [previously](https://github.com/brave/brave-core-crx-packager/pull/740)
- if you've been following along, you might be able to guess that `local-data-files` was indeed fetching the latest version of the component from a remote database, templating the manifest file on disk, then launching a browser instance to zip and sign the CRX file... _ONCE FOR EVERY FILE TO BE INCLUDED IN THE SAME CRX_
- (that is **181 times**, to be precise)
- thankfully, I already removed the adblock and HTTPS Everywhere components from here previously... but they used to be tangled in here too.