### PR TITLE
Use double-quoted template strings in scriptlet wrapper

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -59,7 +59,7 @@ const getRegionalLists = () => getListCatalog().then(catalog => {
 
 // Wraps new template scriptlets with the older "numbered template arg" format and any required dependency code
 const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
-  const args = ['{{1}}', '{{2}}', '{{3}}', '{{4}}', '{{5}}', '{{6}}', '{{7}}', '{{8}}', '{{9}}'];
+  const args = ["{{1}}", "{{2}}", "{{3}}", "{{4}}", "{{5}}", "{{6}}", "{{7}}", "{{8}}", "{{9}}"];
   let last_arg_index = 0;
   for (const arg_index in args) {
     if (args[arg_index] === '{{' + (Number(arg_index) + 1) + '}}') {


### PR DESCRIPTION
With support for quoted args upcoming, template arguments are escaped using JSON string format. JSON only supports double-quoted strings, so these need to be switched for proper compatibility.