### PR TITLE
Update brave-site-specific-scripts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2120,7 +2120,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#f0079aee82a4bbef217da90707208bd00f99766a",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4b164dc2d2ad58d2a2ba604ea3723cfe71c6f761",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -7090,7 +7090,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#f0079aee82a4bbef217da90707208bd00f99766a",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4b164dc2d2ad58d2a2ba604ea3723cfe71c6f761",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Update brave-site-specific-scripts version for Greaselion release.

Related to https://github.com/brave/brave-browser/issues/34367