### PR TITLE
Restore the check for missing adblock manifests when packaging

### DIFF
--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -54,6 +54,12 @@ const processComponent = (binary, endpoint, region, keyDir,
   const parsedManifest = util.parseManifest(originalManifest)
   const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
+  // TODO - previous download failures should prevent the attempt to package the component.
+  if (!fs.existsSync(originalManifest)) {
+    console.warn(`Missing manifest for ${componentSubdir}. Skipping.`)
+    return
+  }
+
   let fileToHash
   if (componentSubdir === regionalCatalogComponentId) {
     fileToHash = 'regional_catalog.json'


### PR DESCRIPTION
Previously, only directories with a `manifest.json` were considered for packaging. Now we look at the list catalog as the source of truth, but we still need to skip components that were not correctly handled in a previous step.

This would have been avoided by https://github.com/brave/brave-core-crx-packager/pull/844 which combines download, manifest generation, and packaging into one abortable function call per-component.