### PR TITLE
Fix packaging failures

### DIFF
--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -51,14 +51,15 @@ const getOriginalManifest = (componentSubdir) => {
 const processComponent = (binary, endpoint, region, keyDir,
   publisherProofKey, localRun, componentSubdir) => {
   const originalManifest = getOriginalManifest(componentSubdir)
-  const parsedManifest = util.parseManifest(originalManifest)
-  const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
   // TODO - previous download failures should prevent the attempt to package the component.
   if (!fs.existsSync(originalManifest)) {
     console.warn(`Missing manifest for ${componentSubdir}. Skipping.`)
     return
   }
+
+  const parsedManifest = util.parseManifest(originalManifest)
+  const id = util.getIDFromBase64PublicKey(parsedManifest.key)
 
   let fileToHash
   if (componentSubdir === regionalCatalogComponentId) {


### PR DESCRIPTION
1st commit resolves extra messages in `#extensions-bot` and publish failures following Sentry warnings (i.e. what https://github.com/brave/brave-core-crx-packager/pull/848 was supposed to do)

2nd commit resolves the <code>internal error in Neon module: byte index 18 is out of bounds of `\,mr=function(r\,`</code> error.
