### PR TITLE
Update to correct release date

### DIFF
--- a/CHANGELOG-go-ipfs.md
+++ b/CHANGELOG-go-ipfs.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Updated kubo to 0.27.0, from 0.26.0 (8-April-2024)
+## Updated kubo to 0.27.0, from 0.26.0 (10-April-2024)
 - [brave-browser#36531](https://github.com/brave/brave-browser/issues/36531) - Update kubo to 0.27.0
 - For full changelog, see https://github.com/ipfs/kubo/releases/tag/v0.27.0
 


### PR DESCRIPTION
As per https://bravesoftware.slack.com/archives/C212VB0RG/p1712748480660519?thread_ts=1712577620.951589&cid=C212VB0RG, component was pushed to release on 10th so need to update the release date in notes to match the actual release date.