### PR TITLE
Update brave-site-specific-scripts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2178,7 +2178,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4b164dc2d2ad58d2a2ba604ea3723cfe71c6f761",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#d44890e3c95429e94d255dae49c483391c87d996",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -7177,7 +7177,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4b164dc2d2ad58d2a2ba604ea3723cfe71c6f761",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#d44890e3c95429e94d255dae49c483391c87d996",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Update brave-site-specific-scripts version for Greaselion release.

Related to https://github.com/brave/brave-browser/issues/38461