### PR TITLE
Add webkit-content-filter-validator step

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -165,14 +165,47 @@ const sampleUnblockedNetworkRequests = [
 /*
  * Throw an error if the list is blocking any of the resources from `sampleNetworkRequests`.
  */
-const sanityCheckList = ({ title, format, data }) => {
-  const filterSet = new FilterSet()
-  filterSet.addFilters(data.split('\n'), { format })
-  const engine = new Engine(filterSet)
-  for (const request of sampleUnblockedNetworkRequests) {
-    const result = engine.check(request[0], request[1], request[2])
-    if (result) {
-      throw new Error(title + ' failed sanity check for ' + request + '. Check for corrupted list contents.')
+const sanityCheckList = async ({ title, format, data }) => {
+  const dataSplit = data.split('\n')
+  {
+    const filterSet = new FilterSet()
+    filterSet.addFilters(dataSplit, { format })
+    const engine = new Engine(filterSet)
+    for (const request of sampleUnblockedNetworkRequests) {
+      const result = engine.check(request[0], request[1], request[2])
+      if (result) {
+        throw new Error(title + ' failed sanity check for ' + request + '. Check for corrupted list contents.')
+      }
+    }
+  }
+
+  // Also, attempt to convert the rules to iOS content blocking syntax via adblock-rust and see if they are valid as per webkit-content-filter-validator.
+  {
+    const filterSet = new FilterSet(true)
+    filterSet.addFilters(dataSplit, { format })
+    const { contentBlockingRules } = filterSet.intoContentBlocking()
+    const response = await fetch('https://2sq625b43mykl2tqumoue7j4k40vkupj.lambda-url.us-west-2.on.aws', {
+      body: JSON.stringify(contentBlockingRules),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    })
+    if (response.status === 400) {
+      const reason = await response.text()
+      if (reason === '') {
+        // Weird lambda-specific issue? Intermittently, responses will be empty 400.
+        // Ignore it for now.
+      } else if (reason === 'Empty extension.\n') {
+        // Some sublists are no-op when converted individually; this is fine.
+      } else {
+        throw new Error(title + ' could not be converted to iOS content blocking syntax. Reason: ' + reason)
+      }
+    } else if (response.status === 413) {
+      // AWS error: payload is too large for the RequestResponse invocation type (limit 6291456 bytes)
+      // Ignore it for now.
+    } else if (response.status !== 200) {
+      throw new Error(title + ' encountered unexpected error (' + response.status + ') during conversion.')
     }
   }
 }

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -194,8 +194,7 @@ const sanityCheckList = async ({ title, format, data }) => {
     if (response.status === 400) {
       const reason = await response.text()
       if (reason === '') {
-        // Weird lambda-specific issue? Intermittently, responses will be empty 400.
-        // Ignore it for now.
+        throw new Error(title + ' could not be converted to iOS content blocking syntax. Reason: out of memory or other lambda-specific issue.')
       } else if (reason === 'Empty extension.\n') {
         // Some sublists are no-op when converted individually; this is fine.
       } else {

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -3,6 +3,8 @@ import { Engine, FilterSet, uBlockResources } from 'adblock-rs'
 import path from 'path'
 import { promises as fs } from 'fs'
 
+import { compress } from '@mongodb-js/zstd'
+
 const uBlockLocalRoot = 'submodules/uBlock'
 const uBlockWebAccessibleResources = path.join(uBlockLocalRoot, 'src/web_accessible_resources')
 const uBlockRedirectEngine = path.join(uBlockLocalRoot, 'src/js/redirect-resources.js')
@@ -184,11 +186,22 @@ const sanityCheckList = async ({ title, format, data }) => {
     const filterSet = new FilterSet(true)
     filterSet.addFilters(dataSplit, { format })
     const { contentBlockingRules } = filterSet.intoContentBlocking()
+    let body = JSON.stringify(contentBlockingRules)
+    const contentType = 'application/json'
+    const headers = {
+      'Content-Type': contentType
+    }
+
+    // The AWS lambda payload size limit is listed as 6291456 bytes,
+    // although it appears to fail even at some lower values.
+    if (body.length >= 5000000) {
+      body = await compress(Buffer.from(body))
+      headers['Content-Encoding'] = 'application/zstd'
+    }
+
     const response = await fetch('https://2sq625b43mykl2tqumoue7j4k40vkupj.lambda-url.us-west-2.on.aws', {
-      body: JSON.stringify(contentBlockingRules),
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      body,
+      headers,
       method: 'POST'
     })
     if (response.status === 400) {
@@ -197,12 +210,15 @@ const sanityCheckList = async ({ title, format, data }) => {
         throw new Error(title + ' could not be converted to iOS content blocking syntax. Reason: out of memory or other lambda-specific issue.')
       } else if (reason === 'Empty extension.\n') {
         // Some sublists are no-op when converted individually; this is fine.
+      } else if (reason === 'Too many rules in JSON array.\n') {
+        // We might eventually want to do something here if a list grows to become too large,
+        // but for lists that are already past the threshold, there's not much we can do.
       } else {
         throw new Error(title + ' could not be converted to iOS content blocking syntax. Reason: ' + reason)
       }
     } else if (response.status === 413) {
       // AWS error: payload is too large for the RequestResponse invocation type (limit 6291456 bytes)
-      // Ignore it for now.
+      throw new Error(title + ' could not be converted to iOS content blocking syntax. Reason: payload too large for AWS Lambda request.')
     } else if (response.status !== 200) {
       throw new Error(title + ' encountered unexpected error (' + response.status + ') during conversion.')
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.602.0",
         "@aws-sdk/client-s3": "3.600.0",
+        "@mongodb-js/zstd": "^1.2.0",
         "@sentry/node": "7.118.0",
         "adblock-rs": "0.8.11",
         "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
@@ -1181,6 +1182,136 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@mongodb-js/zstd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.2.0.tgz",
+      "integrity": "sha512-sKHsJU2MXsp822IFXOHw/4mpFulScNHpZzVy1Zi5k5wBsdiAPx1QramyOXZkpacla+2QPEC/s7TxPlEhG/HuNQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/zstd-darwin-arm64": "1.2.0",
+        "@mongodb-js/zstd-darwin-x64": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-musl": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-musl": "1.2.0",
+        "@mongodb-js/zstd-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-arm64/-/zstd-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-QWgW6IkWp3ErBXOvlOj9lw3lwMfey7eXh/p/Srb/7sEiu1e0yEO+LQ8IctmDWh8bfznKXmwUC0h7LKDbYR30yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-x64/-/zstd-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-VnxYO8P2SWubdnydGId5+6veO6Ki6nxCr/pTaDZd8s4Urn6bDdXSX6YsZ0r42dO3Fa0FVYzrlcVAuNB67e2b6w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-gnu/-/zstd-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-TYF0XgNJW6UrvtY2u4Uuo5HiVWNgWNZ/ae2BhVp8hNsDhwFqb/YNoyiZqBei6whUwr8hecMy0UaHAXm3h+O2+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-musl/-/zstd-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-e2ClmJI1BvJq23VSLH14hgjjjcMOad3R/Ap7Q7dTa1uiVSJG4xKd2CmrWQgX1Az4/EfUMWEI7pb4yuanbdd2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-gnu/-/zstd-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-JuoK8lxUlkFPDBfsBUJKnLxpXA5ar+v7G43lIUlBKgjOp5aEWO/qQp5sNgCRnYA7x6PItYqIkEJjsays4N6JOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-musl/-/zstd-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-pSb1iUF3Gc/qrJuP/Mi5ry4YFAUdUVFKNRZh1KTDDhSWyRCLd9gKcNdRnXqJjIdeGGEKf4bhtZAbYw4i/g0foA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-win32-x64-msvc/-/zstd-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-iz4Yl+WK3yr/4Yg6F4tKz3X9+yMZDK6pyBMA0CdXydSDZs6o2XQ2I0ZSu3oSk/ACfaZX3SNfRi3XTGgAM1eKZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6439,6 +6570,62 @@
           }
         }
       }
+    },
+    "@mongodb-js/zstd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.2.0.tgz",
+      "integrity": "sha512-sKHsJU2MXsp822IFXOHw/4mpFulScNHpZzVy1Zi5k5wBsdiAPx1QramyOXZkpacla+2QPEC/s7TxPlEhG/HuNQ==",
+      "requires": {
+        "@mongodb-js/zstd-darwin-arm64": "1.2.0",
+        "@mongodb-js/zstd-darwin-x64": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-musl": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-musl": "1.2.0",
+        "@mongodb-js/zstd-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "@mongodb-js/zstd-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-arm64/-/zstd-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-QWgW6IkWp3ErBXOvlOj9lw3lwMfey7eXh/p/Srb/7sEiu1e0yEO+LQ8IctmDWh8bfznKXmwUC0h7LKDbYR30yw==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-x64/-/zstd-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-VnxYO8P2SWubdnydGId5+6veO6Ki6nxCr/pTaDZd8s4Urn6bDdXSX6YsZ0r42dO3Fa0FVYzrlcVAuNB67e2b6w==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-gnu/-/zstd-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-TYF0XgNJW6UrvtY2u4Uuo5HiVWNgWNZ/ae2BhVp8hNsDhwFqb/YNoyiZqBei6whUwr8hecMy0UaHAXm3h+O2+Q==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-musl/-/zstd-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-e2ClmJI1BvJq23VSLH14hgjjjcMOad3R/Ap7Q7dTa1uiVSJG4xKd2CmrWQgX1Az4/EfUMWEI7pb4yuanbdd2AQ==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-gnu/-/zstd-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-JuoK8lxUlkFPDBfsBUJKnLxpXA5ar+v7G43lIUlBKgjOp5aEWO/qQp5sNgCRnYA7x6PItYqIkEJjsays4N6JOA==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-musl/-/zstd-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-pSb1iUF3Gc/qrJuP/Mi5ry4YFAUdUVFKNRZh1KTDDhSWyRCLd9gKcNdRnXqJjIdeGGEKf4bhtZAbYw4i/g0foA==",
+      "optional": true
+    },
+    "@mongodb-js/zstd-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-win32-x64-msvc/-/zstd-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-iz4Yl+WK3yr/4Yg6F4tKz3X9+yMZDK6pyBMA0CdXydSDZs6o2XQ2I0ZSu3oSk/ACfaZX3SNfRi3XTGgAM1eKZA==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Packages component and theme extensions used in the Brave browser",
   "type": "module",
   "dependencies": {
-    "adblock-rs": "0.8.11",
     "@aws-sdk/client-dynamodb": "3.602.0",
     "@aws-sdk/client-s3": "3.600.0",
+    "@mongodb-js/zstd": "^1.2.0",
+    "@sentry/node": "7.118.0",
+    "adblock-rs": "0.8.11",
     "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
     "playlist-component": "github:brave/playlist-component",
     "recursive-readdir-sync": "1.0.6",
-    "@sentry/node": "7.118.0",
     "unzip-crx-3": "0.2.0"
   },
   "devDependencies": {

--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -88,9 +88,9 @@ const generateDataFilesForCatalogEntry = (entry) => {
     console.log(`${entry.langs} ${l.url}...`)
     promises.push(util.fetchTextFromURL(l.url)
       .then(data => ({ title: l.title || entry.title, format: l.format, data }))
-      .then(listBuffer => {
+      .then(async listBuffer => {
         const compat = removeIncompatibleRules(preprocess(listBuffer))
-        sanityCheckList(compat)
+        await sanityCheckList(compat)
         return compat
       })
     )

--- a/test/testAdBlock.js
+++ b/test/testAdBlock.js
@@ -32,7 +32,7 @@ test('sanityCheckList', async (t) => {
   const corruptedList = fs.readFileSync('./test/elc-1.0.3814-corrupted.txt', { encoding: 'utf8' })
   let failureMessage
   try {
-    sanityCheckList({ title: 'corrupted list', data: corruptedList, format: 'Standard' })
+    await sanityCheckList({ title: 'corrupted list', data: corruptedList, format: 'Standard' })
   } catch (error) {
     failureMessage = error.message
   }


### PR DESCRIPTION
This will block publishing for any adblock component if the list cannot be converted to the syntax needed by iOS.

~Known limitation: a few of the lists are too large for lambda payloads and can't really be checked this way; we ignore them for now. In the future we can set up an endpoint that accepts compressed payloads.~ Resolved!