### PR TITLE
Use list_catalog.json for the catalog component file hash

### DIFF
--- a/scripts/packageAdBlock.js
+++ b/scripts/packageAdBlock.js
@@ -63,7 +63,7 @@ const processComponent = (binary, endpoint, region, keyDir,
 
   let fileToHash
   if (componentSubdir === regionalCatalogComponentId) {
-    fileToHash = 'regional_catalog.json'
+    fileToHash = 'list_catalog.json'
   } else if (componentSubdir === resourcesComponentId) {
     fileToHash = 'resources.json'
   } else {


### PR DESCRIPTION
This was previously using the old filename for compatibility; it should be safe to update based on the new file going forwards.