### PR TITLE
Update Greaselion version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,7 +2359,7 @@
     },
     "node_modules/brave-site-specific-scripts": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#d44890e3c95429e94d255dae49c483391c87d996",
+      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4e7e0fc2dc89db5f7a690f3d237d65dc94ad79f7",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/chrome": "0.0.100"
@@ -7424,7 +7424,7 @@
       }
     },
     "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#d44890e3c95429e94d255dae49c483391c87d996",
+      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4e7e0fc2dc89db5f7a690f3d237d65dc94ad79f7",
       "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
       "requires": {
         "@types/chrome": "0.0.100"


### PR DESCRIPTION
Update brave-site-specific-scripts version for Greaselion release.

Related to https://github.com/brave/brave-browser/issues/40784
Related to https://github.com/brave/brave-browser/issues/40822