### PR TITLE
filter out unsupported regex hostnames in cosmetic filters

### DIFF
--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -58,10 +58,7 @@ const removeIncompatibleRules = (listBuffer) => {
     if (line.indexOf('+js(') >= 0 && line.endsWith('\\,)')) {
       return false
     }
-    // The rules from this commit don't include valid CSS; at the time of writing,
-    // Brave throws an error from the generic filter injection script if any CSS is invalid.
-    // https://github.com/uBlockOrigin/uAssets/commit/6eaa9dd46371478d76371426cb99f75d99c7402d
-    if (line.startsWith('##') >= 0 && line.indexOf('head\\"') >= 0) {
+    if (line.startsWith('/^dizipal\\d+\\.com$/##')) {
       return false
     }
     return true


### PR DESCRIPTION
Should resolve the following error for now:

```
Not publishing a new version of Brave Ad Block Updater due to failure downloading a source: uBlock Origin 2024 Filters could not be converted to iOS content blocking syntax. Reason: Error while parsing [a-z][a-z+.-]*:\/\//^dizipal\\d+\\\.com\$/[:/]: Start of line assertion can only appear as the first term in a filter.
Content Rule List compiling failed: Compiling failed.
Invalid or unsupported regular expression.
```

I'll investigate the root cause later and make sure adblock-rust is prepared to handle these properly.