### PR TITLE
feat(SmartNTT): support new file name for sponsored images

### DIFF
--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -93,7 +93,7 @@ const isValidSchemaVersion = (version) => {
   return version === jsonSchemaVersion
 }
 
-const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
+const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName = 'photo.json') => {
   return new Promise(function (resolve, reject) {
     let jsonFileBody = '{}'
 
@@ -126,7 +126,7 @@ const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
         return reject(error)
       }
 
-      createPhotoJsonFile(path.join(targetResourceDir, 'photo.json'), JSON.stringify(photoData))
+      createPhotoJsonFile(path.join(targetResourceDir, targetJsonFileName), JSON.stringify(photoData))
 
       // Download image files that specified in jsonFileUrl
       const imageFileNameList = getImageFileNameListFrom(photoData)

--- a/scripts/ntp-sponsored-images/generate.js
+++ b/scripts/ntp-sponsored-images/generate.js
@@ -30,8 +30,12 @@ async function generateNTPSponsoredImages (dataUrl, targetComponents) {
     const targetResourceDir = path.join(rootResourceDir, regionPlatformName)
     mkdirp.sync(targetResourceDir)
     const regionPlatformPath = regionPlatformName.replace('-', '/')
-    const sourceJsonFileUrl = `${dataUrl}${regionPlatformPath}/photo.json`
-    await ntpUtil.prepareAssets(sourceJsonFileUrl, targetResourceDir)
+    const baseJsonFileUrl = `${dataUrl}${regionPlatformPath}`
+
+    await Promise.all([
+      ntpUtil.prepareAssets(`${baseJsonFileUrl}/photo.json`, targetResourceDir),
+      ntpUtil.prepareAssets(`${baseJsonFileUrl}/si-photo.json`, targetResourceDir, 'si-photo.json')
+    ])
   }
 }
 


### PR DESCRIPTION
During the development of SmartNTT, we ran into a blocker where we realized that with the addition of `conditionMatchers` to the `wallpapers` section of an NTT would not be honored in legacy browsers (`1.72.x`). This means that a SmartNTT would show to anyone below that version. In order to remedy this, the "quick-fix" idea was to create a new file called `si-photo.json`. So that way, all new browsers could read the new file, while legacy browsers kept the the same `photo.json` they were used to, without the SmartNTT present in them (as determined by the `ntp-si-assets` packager)