### PR TITLE
feat(smartNTT): process assets in new campaign array

### DIFF
--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -15,7 +15,7 @@ const jsonSchemaVersion = 1
 * @typedef {{ imageUrl: string }} Logo
 * @typedef {{ logo?: Logo, imageUrl: string}} Wallpaper
 * @typedef {{ logo: Logo, wallpapers: Wallpaper[]}} Campaign
-* @typedef {Campaign & { campaigns?: Campaign[], topSites?: { iconUrl }[] }} NTPAssetSchema
+* @typedef {Campaign & { campaigns?: Campaign[], campaigns2?: Campaign[], topSites?: { iconUrl }[] }} NTPAssetSchema
 */
 
 const createPhotoJsonFile = (path, body) => {
@@ -55,6 +55,11 @@ const getImageFileNameListFrom = (photoJsonObj) => {
   )
   if (photoJsonObj.campaigns) {
     for (const campaign of photoJsonObj.campaigns) {
+      getImageFileNameListFromCampaign(campaign).forEach(s => fileList.add(s))
+    }
+  }
+  if (photoJsonObj.campaigns2) {
+    for (const campaign of photoJsonObj.campaigns2) {
       getImageFileNameListFromCampaign(campaign).forEach(s => fileList.add(s))
     }
   }


### PR DESCRIPTION
SmartNTTs are targeted locally by the browser, and only shown to users if the configured conditions match.

Non-smart capable browsers - that pre-date the introduction of this feature - should never show these NTTs. To enforce this:

- the existing campaigns array in photo.json never includes smartNTTs
- a new campaigns2 array is included in photo.json. This includes all NTTs, including smart ones.

SmartNTT capable browsers read the campaigns2 array. Non-smart capable browsers continue to read the campaigns array.

Assets referenced in either of these arrays need to be included within the crx package.

See https://github.com/brave/ntp-si-assets/pull/1192.