### PR TITLE
Fix signing with alternative publisher key

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -115,7 +115,7 @@ const generateCRXFile = (binary, crxFile, privateKeyFile, publisherProofKey,
     `--user-data-dir=${tempUserDataDir}`,
     `--brave-extension-publisher-key=${path.resolve(publisherProofKey)}`]
   if (publisherProofKeyAlt) {
-    args.push(`--brave-extension-publisher-key-alt=${path.resolve(publisherProofKey)}`)
+    args.push(`--brave-extension-publisher-key-alt=${path.resolve(publisherProofKeyAlt)}`)
   }
   const originalOutput = `${inputDir}.crx`
   childProcess.execSync(`${binary} ${args.join(' ')}`)


### PR DESCRIPTION
Components were not signed with the alternative publisher key. This PR fixes that.