### PR TITLE
refactor(ntp-si): read asset list explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ brave-lists
 leo-local-models
 # localstack
 .localstack/
+.vscode/

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -6,70 +6,7 @@ import childProcess from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import util from '../lib/util.js'
-import { Readable } from 'stream'
-import { finished } from 'stream/promises'
-
-const jsonSchemaVersion = 1
-
-/**
-* @typedef {{ imageUrl: string }} Logo
-* @typedef {{ logo?: Logo, imageUrl: string}} Wallpaper
-* @typedef {{ logo: Logo, wallpapers: Wallpaper[]}} Campaign
-* @typedef {Campaign & { campaigns?: Campaign[], campaigns2?: Campaign[], topSites?: { iconUrl }[] }} NTPAssetSchema
-*/
-
-const createPhotoJsonFile = (path, body) => {
-  fs.writeFileSync(path, body)
-}
-
-/**
- *
- * @param {Campaign} campaign
- * @returns {string[]}
- */
-function getImageFileNameListFromCampaign (campaign) {
-  const fileList = new Set()
-  if (campaign.logo) {
-    fileList.add(campaign.logo.imageUrl)
-  }
-  if (campaign.wallpapers) {
-    campaign.wallpapers.forEach((wallpaper) => {
-      fileList.add(wallpaper.imageUrl)
-      // V2 feature - support per-wallpaper logo
-      if (wallpaper.logo && wallpaper.logo.imageUrl) {
-        fileList.add(wallpaper.logo.imageUrl)
-      }
-    })
-  }
-  return Array.from(fileList.values())
-}
-
-/**
- *
- * @param {NTPAssetSchema} photoJsonObj
- * @returns {string[]}
- */
-const getImageFileNameListFrom = (photoJsonObj) => {
-  const fileList = new Set(
-    getImageFileNameListFromCampaign(photoJsonObj)
-  )
-  if (photoJsonObj.campaigns) {
-    for (const campaign of photoJsonObj.campaigns) {
-      getImageFileNameListFromCampaign(campaign).forEach(s => fileList.add(s))
-    }
-  }
-  if (photoJsonObj.campaigns2) {
-    for (const campaign of photoJsonObj.campaigns2) {
-      getImageFileNameListFromCampaign(campaign).forEach(s => fileList.add(s))
-    }
-  }
-  if (photoJsonObj.topSites) {
-    photoJsonObj.topSites.forEach((topSiteObj) => {
-      fileList.add(topSiteObj.iconUrl)
-    })
-  }
-  return Array.from(fileList.values())
-}
+import { pipeline } from 'stream/promises'
 
 const generatePublicKeyAndID = (privateKeyFile) => {
   childProcess.execSync(`openssl rsa -in ${privateKeyFile} -pubout -out public.pub`)
@@ -94,61 +31,49 @@ const generatePublicKeyAndID = (privateKeyFile) => {
   }
 }
 
-const isValidSchemaVersion = (version) => {
-  return version === jsonSchemaVersion
+const downloadFile = async (sourceUrl, dest) => {
+  const response = await fetch(sourceUrl)
+
+  if (!response.ok) {
+    throw new Error(`download of ${sourceUrl} failed with code ${response.status}`)
+  }
+
+  if (!response.body) {
+    throw new Error(`download of ${sourceUrl} failed with empty body`)
+  }
+
+  const file = fs.createWriteStream(dest)
+  await pipeline(response.body, file)
 }
 
-const prepareAssets = (jsonFileUrl, targetResourceDir, targetJsonFileName) => {
-  return new Promise(function (resolve, reject) {
-    let jsonFileBody = '{}'
+const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
+  const response = await fetch(jsonFileUrl)
 
-    // Download and parse jsonFileUrl.
-    // If it doesn't exist, create with empty object.
-    fetch(jsonFileUrl).then(async function (response) {
-      if (response.status === 200) {
-        jsonFileBody = await response.text()
-      }
-      let photoData = {}
-      try {
-        console.log(`Start - json file ${jsonFileUrl} parsing`)
-        photoData = JSON.parse(jsonFileBody)
-      } catch (err) {
-        console.error(`Invalid json file ${jsonFileUrl}`)
-        return reject(err)
-      }
-      console.log(`Done - json file ${jsonFileUrl} parsing`)
-      // Make sure the data has a schema version so that clients can opt to parse or not
-      let incomingSchemaVersion = photoData.schemaVersion
-      console.log(`Schema version: ${incomingSchemaVersion} from ${jsonFileUrl}`)
-      if (!incomingSchemaVersion) {
-        // Source has no schema version, assume and set current version.
-        // TODO(petemill): Don't allow this once the source is established to always
-        // have a schema version.
-        incomingSchemaVersion = jsonSchemaVersion
-      } else if (!isValidSchemaVersion(incomingSchemaVersion)) {
-        const error = `Error: Cannot parse JSON data at ${jsonFileUrl} since it has a schema version of ${incomingSchemaVersion} but we expected ${jsonSchemaVersion}! This region will not be updated.`
-        console.error(error)
-        return reject(error)
-      }
+  if (!response.ok) {
+    throw new Error(`download of ${jsonFileUrl} failed with code ${response.status}`)
+  }
 
-      createPhotoJsonFile(path.join(targetResourceDir, 'photo.json'), JSON.stringify(photoData))
+  console.log(` Reading ${jsonFileUrl}`)
 
-      // Download image files that specified in jsonFileUrl
-      const imageFileNameList = getImageFileNameListFrom(photoData)
-      const downloadOps = imageFileNameList.map(async (imageFileName) => {
-        const targetImageFilePath = path.join(targetResourceDir, imageFileName)
-        const targetImageFileUrl = new URL(imageFileName, jsonFileUrl).href
-        const response = await fetch(targetImageFileUrl)
-        const ws = fs.createWriteStream(targetImageFilePath)
-        return finished(Readable.fromWeb(response.body).pipe(ws))
-          .then(() => console.log(targetImageFileUrl))
-      })
-      await Promise.all(downloadOps)
-      resolve()
-    }).catch(error => {
-      throw new Error(`Error from ${jsonFileUrl}: ${error.cause}`)
-    })
+  // example file format:
+  // https://github.com/brave/ntp-si-assets/blob/966021c07cf1dcb58128c0b0487b8bd974f4eda8/resources/test-data/examples/assets.json
+  const json = await response.json()
+
+  const allDownloads = json.assets.map(async asset => {
+    const targetAssetFilePath = path.join(targetResourceDir, asset.path)
+    const targetAssetFileUrl = new URL(asset.path, jsonFileUrl).href
+
+    await downloadFile(targetAssetFileUrl, targetAssetFilePath)
+
+    const hash = util.generateSHA256HashOfFile(targetAssetFilePath)
+    if (hash !== asset.sha256) {
+      throw new Error(`${targetAssetFileUrl}: hash does not match, expected ${asset.sha256} got ${hash}`)
+    }
+
+    console.log(" " + targetAssetFileUrl)
   })
+
+  await Promise.all(allDownloads)
 }
 
 export default {

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -70,7 +70,7 @@ const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
       throw new Error(`${targetAssetFileUrl}: hash does not match, expected ${asset.sha256} got ${hash}`)
     }
 
-    console.log(" " + targetAssetFileUrl)
+    console.log(' ' + targetAssetFileUrl)
   })
 
   await Promise.all(allDownloads)

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -52,10 +52,10 @@ const downloadFile = async (sourceUrl, dest) => {
 }
 
 const validateTargetPath = (rootPath, targetPath) => {
-  const normalisedRoot = path.normalize(rootPath)
-  const normalisedTarget = path.normalize(targetPath)
+  const resolvedRoot = path.resolve(rootPath)
+  const resolvedTarget = path.resolve(targetPath)
 
-  if (!normalisedTarget.startsWith(normalisedRoot)) {
+  if (!resolvedTarget.startsWith(resolvedRoot)) {
     throw new Error(`path ${targetPath} traverses outside of root ${rootPath}`)
   }
 }

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -42,8 +42,22 @@ const downloadFile = async (sourceUrl, dest) => {
     throw new Error(`download of ${sourceUrl} failed with empty body`)
   }
 
+  // ensure target directory exists
+  const targetDirectory = path.dirname(dest)
+  fs.mkdirSync(targetDirectory, { recursive: true })
+
+  // and download
   const file = fs.createWriteStream(dest)
   await pipeline(response.body, file)
+}
+
+const validateTargetPath = (rootPath, targetPath) => {
+  const normalisedRoot = path.normalize(rootPath)
+  const normalisedTarget = path.normalize(targetPath)
+
+  if (!normalisedTarget.startsWith(normalisedRoot)) {
+    throw new Error(`path ${targetPath} traverses outside of root ${rootPath}`)
+  }
 }
 
 const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
@@ -63,6 +77,7 @@ const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
     const targetAssetFilePath = path.join(targetResourceDir, asset.path)
     const targetAssetFileUrl = new URL(asset.path, jsonFileUrl).href
 
+    validateTargetPath(targetResourceDir, targetAssetFilePath)
     await downloadFile(targetAssetFileUrl, targetAssetFilePath)
 
     const hash = util.generateSHA256HashOfFile(targetAssetFilePath)
@@ -78,5 +93,6 @@ const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
 
 export default {
   generatePublicKeyAndID,
-  prepareAssets
+  prepareAssets,
+  validateTargetPath
 }

--- a/lib/ntpUtil.test.js
+++ b/lib/ntpUtil.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import ntpUtil from './ntpUtil.js'
+import path from 'node:path'
+
+test('should validate path does not traverse outside of target', () => {
+  const rootDir = fs.mkdtempSync('ntp-util-test')
+
+  // success cases
+  ntpUtil.validateTargetPath(rootDir, rootDir)
+  ntpUtil.validateTargetPath(rootDir, path.join(rootDir, 'file.json'))
+  ntpUtil.validateTargetPath(rootDir, path.join(rootDir, 'subdir/file.json'))
+  ntpUtil.validateTargetPath(rootDir, path.join(rootDir, './file.json'))
+
+  // failure
+  assert.throws(() =>
+    ntpUtil.validateTargetPath(rootDir, path.join(rootDir, '../file.json')),
+  /path file.json traverses outside of root/)
+})

--- a/scripts/ntp-sponsored-images/generate.js
+++ b/scripts/ntp-sponsored-images/generate.js
@@ -30,7 +30,7 @@ async function generateNTPSponsoredImages (dataUrl, targetComponents) {
     const targetResourceDir = path.join(rootResourceDir, regionPlatformName)
     mkdirp.sync(targetResourceDir)
     const regionPlatformPath = regionPlatformName.replace('-', '/')
-    const sourceJsonFileUrl = `${dataUrl}${regionPlatformPath}/photo.json`
+    const sourceJsonFileUrl = `${dataUrl}${regionPlatformPath}/assets.json`
     await ntpUtil.prepareAssets(sourceJsonFileUrl, targetResourceDir)
   }
 }


### PR DESCRIPTION
The ntp-si packaging logic had intimate knowledge of the internal format of `photo.json` in order to determine the set of assets to be included in the crx.

This PR shifts that responsibility to `ntp-si-assets`, which as of https://github.com/brave/ntp-si-assets/pull/1240 now publishes an additional file `assets.json` explicitly containing the list of files to be packaged. See [example](https://mobile-data.s3.brave.com/GB/desktop/assets.json).

This is a pre-req for rich NTTs, which will have a wider variety of assets. That isn't implemented server-side yet: this change is in preparation for reducing the number of places that are impacted when it is. So currently there should be no visible difference with this change: it's a pure refactor.

Re #1039