### PR TITLE
Add YouTube script injector component

### DIFF
--- a/component-data/youtube-script-injector/manifest.json
+++ b/component-data/youtube-script-injector/manifest.json
@@ -1,0 +1,7 @@
+{
+   "description": "Brave YouTube Injector Component",
+   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnwhDV1BTzTeDNsi+DxnyxrKqugj/a/8dKQE8usNweMkpORdxFxflbJkA5IErDyW3xca63pdMYhArPjHr0OUBACYKBfzEYF/Yo0kNxxJLWylr7FKwZxOKosmlZXUW8J2wtFu8ua6oQB2lEOk7y2jxwUAka/a0JPxeDsU9ByadmAdVZ7aaiCEGsJgEtHrpPha/2AJi8xerYLeB4bFfFc2bdXKEsN4UzjVLYpCfsKAuxEtO2QC2+Rylz60Vq3ANjjnlXINDJrl3jsSwF6GXHEE4Qzl7Qvu142N9G2rsSxMyPlunD8EGrEjK9fGRc6RPGQy1LbyY3imXpiDp0vXicCaYuwIDAQAB",
+   "manifest_version": 2,
+   "name": "Brave YouTube Injector",
+   "version": "0.0.0"
+}

--- a/component-data/youtube-script-injector/scripts/extra-controls-fullscreen.js
+++ b/component-data/youtube-script-injector/scripts/extra-controls-fullscreen.js
@@ -1,0 +1,39 @@
+function triggerFullscreen() {
+  // Always play video before entering fullscreen mode.
+document.querySelector("video.html5-main-video")?.play();
+// Check if the video is not in fullscreen mode already.
+if (!document.fullscreenElement) {
+  // Create a MutationObserver to watch for changes in the DOM.
+  const observer = new MutationObserver((_mutationsList, observer) => {
+    var fullscreenBtn = document.querySelector("button.fullscreen-icon");
+    if (fullscreenBtn) {
+      observer.disconnect()
+      fullscreenBtn.click();
+    }
+  });
+
+  var fullscreenBtn = document.querySelector("button.fullscreen-icon");
+  // Check if fullscreen button is available.
+  if (fullscreenBtn) {
+    fullscreenBtn.click();
+  } else {
+    // When fullscreen button is not available
+    // clicking the movie player resume the UI.
+    var moviePlayer = document.getElementById("movie_player");
+    if (moviePlayer) {
+      // Start observing the DOM.
+      observer.observe(document.body, { childList: true, subtree: true });
+      // Make sure the player is in focus or responsive.
+      moviePlayer.click();
+    }
+  }
+}
+}
+
+if (document.readyState === "loading") {
+  // Loading hasn't finished yet.
+  document.addEventListener("DOMContentLoaded", triggerFullscreen);
+} else {
+  // `DOMContentLoaded` has already fired.
+  triggerFullscreen();
+}

--- a/component-data/youtube-script-injector/scripts/extra-controls-pip.js
+++ b/component-data/youtube-script-injector/scripts/extra-controls-pip.js
@@ -1,0 +1,53 @@
+(function() {
+  const script = document.createElement('script');
+  script.textContent = `
+  function enterPictureInPicture() {
+    brave?.nativePipMode();
+  }
+  `;
+
+  document.head.appendChild(script);
+  script.remove();
+}());
+
+const observer = new MutationObserver((_mutationsList) => {
+  addPipButton();
+});
+  
+function addPipButton() {
+  const fullscreenButton = document.querySelector("button.fullscreen-icon");
+  if (!fullscreenButton) {
+    return;
+  }
+
+  const fullscreenButtonParent = fullscreenButton.closest("div");
+  if (!fullscreenButtonParent) {
+    return;
+  }
+
+  if (fullscreenButtonParent.querySelector("button.pip-icon")) {
+    return;
+  }
+
+  fullscreenButtonParent.style.display = "flex";
+  const pipButtonHTML = `
+  <button class="icon-button pip-icon" aria-label="Enter picture-in-picture mode" onclick="enterPictureInPicture()">
+  <c3-icon style="">
+    <span class="yt-icon-shape yt-spec-icon-shape">
+      <div style="width: 100%; height: 100%; display: block; fill: currentcolor;">
+        <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24" focusable="false" aria-hidden="true" style="pointer-events: none; display: inherit; width: 100%; height: 100%;">
+          <path d="M6,6h12v12H6V6z M15,9h-4v4h4V9z"></path>
+        </svg>
+      </div>
+    </span>
+  </c3-icon>
+  </button>
+  `;
+  fullscreenButtonParent.insertAdjacentHTML("afterbegin", pipButtonHTML);
+  return true;
+}
+
+window.addEventListener("load", () => {
+  addPipButton();
+  observer.observe(document.body, { childList: true, subtree: true });
+});

--- a/component-data/youtube-script-injector/scripts/playback-video.js
+++ b/component-data/youtube-script-injector/scripts/playback-video.js
@@ -1,0 +1,19 @@
+(function() {
+  const script = document.createElement('script');
+  // Modify the listener by ignoring visibilitychange
+  // so when the app goes in background the video
+  // is not paused.
+  script.textContent = `
+  if (document._addEventListener === undefined) {
+    document._addEventListener = document.addEventListener;
+    document.addEventListener = function(a,b,c) {
+      if(a != 'visibilitychange') {
+        document._addEventListener(a,b,c);
+      }
+    };
+  }
+  `;
+  
+  document.head.appendChild(script);
+  script.remove();
+}());

--- a/component-data/youtube-script-injector/youtube.json
+++ b/component-data/youtube-script-injector/youtube.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "playback_video_script": "playback-video.js",
+  "extra_controls_fullscreen_script": "extra-controls-fullscreen.js",
+  "extra_controls_pip_script": "extra-controls-pip.js"
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "package-ntp-super-referrer": "node scripts/packageNTPSuperReferrerComponent.js",
     "package-ntp-super-referrer-mapping-table": "node scripts/packageNTPSuperReferrerMappingTableComponent.js",
     "package-playlist": "node ./scripts/packagePlaylist.js",
+    "package-youtube-script-injector": "node ./scripts/packageYouTubeScriptInjector.js",
     "package-brave-user-agent": "node ./scripts/packageBraveUserAgentComponent.js",
     "package-user-model-installer-updates": "node ./scripts/packageBraveAdsResourcesComponent",
     "generate-puffpatches": "node ./scripts/generatePuffpatches",

--- a/scripts/packageYouTubeScriptInjector.js
+++ b/scripts/packageYouTubeScriptInjector.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+//  npm run package-youtube-script-injector -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/key.pem
+
+import commander from 'commander'
+import fs from 'fs-extra'
+import { mkdirp } from 'mkdirp'
+import path from 'path'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
+
+const getOriginalManifest = () => {
+  return path.join(path.resolve(), 'component-data', 'youtube-script-injector', 'manifest.json')
+}
+
+const stageFiles = util.stageDir.bind(
+  undefined,
+  path.join(path.resolve(), 'component-data', 'youtube-script-injector'),
+  getOriginalManifest())
+
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+  publisherProofKey, publisherProofKeyAlt) => {
+  const stagingDir = path.join('build', 'youtube-script-injector')
+  const crxFile = path.join(stagingDir, 'youtube-script-injector.crx')
+  mkdirp.sync(stagingDir)
+  util.getNextVersion(endpoint, region, componentID).then((version) => {
+    stageFiles(version, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+      publisherProofKeyAlt, stagingDir)
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+util.installErrorHandlers()
+
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key-file <file>', 'file containing private key for signing crx file'))
+  .parse(process.argv)
+
+let privateKeyFile = ''
+if (fs.existsSync(commander.keyFile)) {
+  privateKeyFile = commander.keyFile
+} else {
+  throw new Error('Missing or invalid private key')
+}
+
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  const [, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+    componentID, privateKeyFile, commander.publisherProofKey, commander.publisherProofKeyAlt)
+})


### PR DESCRIPTION
Adds packaging logic for a new component with id `ninjlighifanhiflenpeafpnanjemako`.

Required for https://github.com/brave/brave-core/pull/26355

This will need a new Jenkins job as well.

PEM is uploaded to 1Password `Developers Shared` in `YouTube Script Injector Component`.
