### PR TITLE
feat: support downloading ntp assets directly from s3

### DIFF
--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -32,21 +32,12 @@ const generatePublicKeyAndID = (privateKeyFile) => {
 }
 
 const downloadFile = async (sourceUrl, dest) => {
-  const response = await fetch(sourceUrl)
-
-  if (!response.ok) {
-    throw new Error(`download of ${sourceUrl} failed with code ${response.status}`)
-  }
-
-  if (!response.body) {
-    throw new Error(`download of ${sourceUrl} failed with empty body`)
-  }
-
   // ensure target directory exists
   const targetDirectory = path.dirname(dest)
   fs.mkdirSync(targetDirectory, { recursive: true })
 
   // and download
+  const response = await util.s3capableFetch(sourceUrl)
   const file = fs.createWriteStream(dest)
   await pipeline(response.body, file)
 }
@@ -61,11 +52,7 @@ const validateTargetPath = (rootPath, targetPath) => {
 }
 
 const prepareAssets = async (jsonFileUrl, targetResourceDir) => {
-  const response = await fetch(jsonFileUrl)
-
-  if (!response.ok) {
-    throw new Error(`download of ${jsonFileUrl} failed with code ${response.status}`)
-  }
+  const response = await util.s3capableFetch(jsonFileUrl)
 
   console.log(` Reading ${jsonFileUrl}`)
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -186,6 +186,57 @@ const parseManifest = (manifestFile) => {
   return JSON.parse(json)
 }
 
+// IAM permissions of the running job should prevent access to unintended buckets.
+// And the source of bucket names should always be the jenkins job configuration.
+// However, as an additional layer of protection, ensure we only attempt to download
+// from the buckets we expect.
+const permittedBuckets = [
+  "brave-theme-customizations-dev",
+  "brave-theme-customizations"
+]
+
+/**
+ * Returns a fetch-style response object for the given url. Both https:
+ * and s3: style urls are supported.
+ * 
+ * Note only the body fields in the response are fully populated, but this code
+ * already throws on a non successful http response code, and s3 failures throw
+ * errors on failure anyway.
+ *
+ * @param {string} sourceUrl either an https:// url or a s3 path such as s3://bucket/key
+ * @returns {Promise<Response>} a "fetch" response object
+ */
+const s3capableFetch = async (sourceUrl) => {
+  const source = new URL(sourceUrl)
+
+  if (source.protocol === 'https:') {
+    const response = await fetch(source)
+    if (!response.ok) {
+      throw new Error(`download of ${sourceUrl} failed with code ${response.status}`)
+    }
+    return response
+  }
+
+  if (source.protocol === 's3:') {
+    const bucket = source.host;
+    const key = source.pathname.slice(1) // drop the leading "/" from the key, s3 keys don't use this
+
+    if (!permittedBuckets.includes(bucket)) {
+      throw new Error(`download of ${sourceUrl} rejected as not a permitted bucket`)
+    }
+
+    const command = new GetObjectCommand({ Bucket: bucket, Key: key })
+    const s3response = await s3Client.send(command)
+    if (!s3response.Body) {
+      throw new Error(`download of ${sourceUrl} failed with unexpectedly empty body`)
+    }
+    return new Response(s3response.Body)
+  }
+
+  throw new Error(`unsupported protocol in ${sourceUrl}`)
+}
+
+
 const downloadFileFromS3 = async (key, outputPath, hashAsFilename = false) => {
   const command = new GetObjectCommand({ Bucket: S3_EXTENSIONS_BUCKET, Key: key })
 
@@ -692,5 +743,6 @@ export default {
   copyManifestWithVersion,
   stageDir,
   stageFiles,
-  generateVerifiedContents
+  generateVerifiedContents,
+  s3capableFetch
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -191,14 +191,14 @@ const parseManifest = (manifestFile) => {
 // However, as an additional layer of protection, ensure we only attempt to download
 // from the buckets we expect.
 const permittedBuckets = [
-  "brave-theme-customizations-dev",
-  "brave-theme-customizations"
+  'brave-theme-customizations-dev',
+  'brave-theme-customizations'
 ]
 
 /**
  * Returns a fetch-style response object for the given url. Both https:
  * and s3: style urls are supported.
- * 
+ *
  * Note only the body fields in the response are fully populated, but this code
  * already throws on a non successful http response code, and s3 failures throw
  * errors on failure anyway.
@@ -218,7 +218,7 @@ const s3capableFetch = async (sourceUrl) => {
   }
 
   if (source.protocol === 's3:') {
-    const bucket = source.host;
+    const bucket = source.host
     const key = source.pathname.slice(1) // drop the leading "/" from the key, s3 keys don't use this
 
     if (!permittedBuckets.includes(bucket)) {
@@ -235,7 +235,6 @@ const s3capableFetch = async (sourceUrl) => {
 
   throw new Error(`unsupported protocol in ${sourceUrl}`)
 }
-
 
 const downloadFileFromS3 = async (key, outputPath, hashAsFilename = false) => {
   const command = new GetObjectCommand({ Bucket: S3_EXTENSIONS_BUCKET, Key: key })

--- a/scripts/ntp-sponsored-images/generate.js
+++ b/scripts/ntp-sponsored-images/generate.js
@@ -38,7 +38,7 @@ async function generateNTPSponsoredImages (dataUrl, targetComponents) {
 util.installErrorHandlers()
 
 commander
-  .option('-d, --data-url <url>', 'url that refers to data that has ntp sponsored images')
+  .option('-d, --data-url <url>', 'https: or s3: url that refers to data that has ntp sponsored images')
   .option('-t, --target-regions <regions>', 'Comma separated list of regions that should generate SI component. For example: "AU-android,US-desktop,GB-ios"', '')
   .option('-u, --excluded-target-regions <regions>', 'Comma separated list of regions that should not generate SI component. For example: "AU-android,US-desktop,GB-ios"', '')
   .parse(process.argv)


### PR DESCRIPTION
Teach both the `generate-ntp-background-images` and `generate-ntp-sponsored-images` jobs to permit a `--data-url` in s3 form, as well as https, e.g.:

```
npm run generate-ntp-sponsored-images -- \
  --data-url=s3://brave-theme-customizations-dev/ \
  --target-regions GB-desktop
```

Which causes them to download directly from the s3 bucket using s3 apis if specified.

On merge of this PR there will be no changes to the execution of the jobs, as the configured `--data-url` will remain https:.

However, I will then subsequently update the jenkins job configs (e.g. [here](https://github.com/brave/devops/blob/c42993bd30f14b186ecff434310220f7fb567640/jenkins/jobs/extensions/brave-core-ext-ntp-sponsored-publish.yml#L45)) to specify an s3: url instead of an https mobile-data url, avoiding the need to synchronise updates to both this script and the jenkins configuration.

Part of the work to retire the public mobile-data.brave.com host which presents a security risk to brave.com, see [google doc](https://docs.google.com/document/d/1f74xRi6dzYiEvbmhnEQEqhn8w7H6KvlBSIqd8qNcmbA/edit?tab=t.0#heading=h.ba278drzw512).