### PR TITLE
The AWS error does not contain a 'code' member. Using 'name' instead.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -550,7 +550,7 @@ const uploadExtension = async (name, id, version, hash, crxFile) => {
   try {
     await s3Client.send(new HeadObjectCommand(headObjectParams))
   } catch (err) {
-    if (err.code === 'NotFound') {
+    if (err.name === 'NotFound') {
       // No need to update tags if the file doesn't exist
       return
     } else {


### PR DESCRIPTION
As said in the aws documentation and explained in [this](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/the-response-object.html) example, we need to use `.name` instead of `.code` member to check the error type.