### PR TITLE
Using POSIX paths on all platforms.

### DIFF
--- a/lib/contentSign.js
+++ b/lib/contentSign.js
@@ -22,7 +22,7 @@ const getComponentFiles = (dir, patterns) => {
     ...new Set(
       files
         .map((f) => {
-          return path.join(dir, f)
+          return path.posix.join(dir, f)
         })
         .filter((f) => {
           return !fs.statSync(f).isDirectory()
@@ -118,7 +118,7 @@ const signPayload = (protectedBy, payload, privateKey) => {
 }
 
 const ensureTrailingSlash = (aPath) => {
-  return path.join(aPath, '/')
+  return path.posix.join(aPath, '/')
 }
 
 const createVerifiedContents = (

--- a/lib/crx.js
+++ b/lib/crx.js
@@ -146,10 +146,14 @@ const generateCrx = async (
 
   const zip = await zipContent(stagingDir)
   const header = signContentAndCreateHeader(zip, extensionKey, publisherKeys)
+  let verifiedContents = null
   if (verifiedContentsKeyFile) {
-    header.verified_contents = zlib.gzipSync(
-      util.generateVerifiedContents(stagingDir, ['**'], verifiedContentsKeyFile)
+    verifiedContents = util.generateVerifiedContents(
+      stagingDir,
+      ['**'],
+      verifiedContentsKeyFile
     )
+    header.verified_contents = zlib.gzipSync(verifiedContents)
   }
 
   const pbf = new Pbf()
@@ -167,7 +171,8 @@ const generateCrx = async (
   return {
     crx: Buffer.concat([crx, headerData, zip]),
     zip,
-    manifest
+    manifest,
+    verifiedContents
   }
 }
 

--- a/scripts/packageManifestV2Extensions.js
+++ b/scripts/packageManifestV2Extensions.js
@@ -75,11 +75,15 @@ const packageV2Extension = (
   const id = util.getIDFromBase64PublicKey(config.key)
   const extensionCrxFile = path.join('build', 'extensions-v2', `${id}.crx`)
   const extensionZipFile = path.join('build', 'extensions-v2', `${id}.zip`)
+  const verifiedContentsFile = path.join('build', 'extensions-v2', `${id}.json`)
 
   const writeOutputFiles = (extension) => {
     fs.mkdirSync(path.join('build', 'extensions-v2'), { recursive: true })
     fs.writeFileSync(extensionCrxFile, extension.crx)
     fs.writeFileSync(extensionZipFile, extension.zip)
+    if (extension.verifiedContents) {
+      fs.writeFileSync(verifiedContentsFile, extension.verifiedContents)
+    }
   }
 
   const processExtension = async () => {


### PR DESCRIPTION
Verified contents payload requires the use of '/' in paths.
This change enables the generation of verified contents on Windows.
Current CI jobs generates the right content  because they're running on Linux.

Also added export of the verified content to the file for debug purposes.