### PR TITLE
feat: enable verified contents for ntp-si packages

### DIFF
--- a/scripts/ntp-sponsored-images/package.js
+++ b/scripts/ntp-sponsored-images/package.js
@@ -47,7 +47,7 @@ function getManifestPath (regionPlatform) {
 }
 
 const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion,
-  componentData, publisherProofKey, publisherProofKeyAlt) => {
+  componentData, publisherProofKey, publisherProofKeyAlt, verifiedContentsKey) => {
   const rootBuildDir = path.join(path.resolve(), 'build', 'ntp-sponsored-images')
   const stagingDir = path.join(rootBuildDir, 'staging', platformRegion)
   const crxOutputDir = path.join(rootBuildDir, 'output')
@@ -58,6 +58,7 @@ const generateCRXFile = (binary, endpoint, region, keyDir, platformRegion,
     // Desktop private key file names do not have the -desktop suffix, but android has -android
     const privateKeyFile = path.join(keyDir, `ntp-sponsored-images-${platformRegion.replace('-desktop', '')}.pem`)
     stageFiles(platformRegion, version, stagingDir)
+    util.generateAndWriteVerifiedContents(stagingDir, ['**'], verifiedContentsKey)
     util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
       publisherProofKeyAlt, stagingDir)
     console.log(`Generated ${crxFile} with version number ${version}`)
@@ -88,6 +89,7 @@ util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
     generateManifestFile(platformRegion, componentData)
     generateCRXFile(commander.binary, commander.endpoint, commander.region,
       keyDir, platformRegion, componentData,
-      commander.publisherProofKey, commander.publisherProofKeyAlt)
+      commander.publisherProofKey, commander.publisherProofKeyAlt,
+      commander.verifiedContentsKey)
   }
 })


### PR DESCRIPTION
Generates the verified_contents.json file for all of the new tab page sponsored image packages.

Validation steps:
1. I've run this code in a forced dev build - https://ci.brave.com/view/extensions-dev/job/brave-core-ext-ntp-sponsored-publish-dev/475/.
2. That published GB-desktop 1.0.233
3. I can see that CRX included `brave_metadata\verified_contents.json`
4. My browser successfully downloaded that and started using that package
5. I can see locally that `brave_metadata\verified_contents.json` exists

What I don't know how to check is that it covered all the files within the CRX correctly (using glob `**`) and how to check that if I change one of those files the browser rejects the CRX. 