### PR TITLE
Fix `[ERR_INVALID_MODULE_SPECIFIER]: Invalid module` in Windows

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -75,7 +75,7 @@ const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
 }`
 
 const generateResources = lazyInit(async () => {
-  const { builtinScriptlets } = await import(new URL(path.join('..', uBlockScriptlets).toString(), import.meta.url))
+  const { builtinScriptlets } = await import(path.join('..', uBlockScriptlets).toString())
 
   const dependencyMap = builtinScriptlets.reduce((map, entry) => {
     map[entry.name] = entry

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -1,7 +1,7 @@
 import { Engine, FilterSet, uBlockResources } from 'adblock-rs'
 import { filterIsProblematic } from './adBlockRust0_8_6/adblock_rust_0_8_6_compat_checker.js'
 
-import path from 'path'
+import path from 'path/posix'
 import { promises as fs } from 'fs'
 
 import { compress } from '@mongodb-js/zstd'

--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -75,7 +75,7 @@ const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
 }`
 
 const generateResources = lazyInit(async () => {
-  const { builtinScriptlets } = await import(path.join('..', uBlockScriptlets).toString())
+  const { builtinScriptlets } = await import(new URL(path.join('..', uBlockScriptlets).toString(), import.meta.url))
 
   const dependencyMap = builtinScriptlets.reduce((map, entry) => {
     map[entry.name] = entry


### PR DESCRIPTION
Fixes https://github.com/brave/brave-core-crx-packager/issues/1091 

Running `npm run data-files-ad-block-rust` works on Linux, but not on Windows with this relative path ` ..\submodules\uBlock\src\js\resources\scriptlets.js` generated by the script.

https://github.com/brave/brave-core-crx-packager/blob/f8ad7c2fb06c8856e532cda5f44748a84313515c/lib/adBlockRustUtils.js#L78

This is something that happens often for the way Windows vs Unix handle paths differently and the slashes and all that.