### PR TITLE
Also support `!#if ext_devbuild`

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -229,6 +229,7 @@ const sanityCheckList = async ({ title, format, data }) => {
 const IF_CONDITIONS = new Map([
   ['ext_ublock', true],
   // [ 'ext_ubol', 'ubol' ],
+  ['ext_devbuild', false],
   ['env_devbuild', false],
   ['env_chromium', true],
   ['env_edge', false],


### PR DESCRIPTION
#1105 added support for `!#if env_devbuild` which appeared in lists, but official documentation only refers to an `ext_devbuild` condition - we should support both.