### PR TITLE
Remove brave-site-specific-scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,10 @@
         "@mongodb-js/zstd": "^1.2.0",
         "@sentry/node": "7.120.3",
         "adblock-rs": "0.9.8",
-        "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
         "p3a-config": "github:brave/p3a-config",
         "p3a-config-staging": "github:brave/p3a-config#staging",
         "pbf": "4.0.1",
         "playlist-component": "github:brave/playlist-component",
-        "recursive-readdir-sync": "1.0.6",
         "unzip-crx-3": "0.2.0"
       },
       "devDependencies": {
@@ -2039,27 +2037,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@types/chrome": {
-      "version": "0.0.100",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.100.tgz",
-      "integrity": "sha512-6wqc/WJyPvS9TrSRcvETIJ02r658weQy2q5CM4wiJRDax5UFcsWXAtZcr0ENSCvcLHrHvYLelYymO8CKxE+iLg==",
-      "dependencies": {
-        "@types/filesystem": "*"
-      }
-    },
-    "node_modules/@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
-      "dependencies": {
-        "@types/filewriter": "*"
-      }
-    },
-    "node_modules/@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
-    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2386,14 +2363,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/brave-site-specific-scripts": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4e7e0fc2dc89db5f7a690f3d237d65dc94ad79f7",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/chrome": "0.0.100"
       }
     },
     "node_modules/browser-level": {
@@ -5134,11 +5103,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/recursive-readdir-sync": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz",
-      "integrity": "sha1-Hb9tMvPFu4083pemxYjVR6nhPVY="
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -7758,27 +7722,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "@types/chrome": {
-      "version": "0.0.100",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.100.tgz",
-      "integrity": "sha512-6wqc/WJyPvS9TrSRcvETIJ02r658weQy2q5CM4wiJRDax5UFcsWXAtZcr0ENSCvcLHrHvYLelYymO8CKxE+iLg==",
-      "requires": {
-        "@types/filesystem": "*"
-      }
-    },
-    "@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
-      "requires": {
-        "@types/filewriter": "*"
-      }
-    },
-    "@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
-    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -7995,13 +7938,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "brave-site-specific-scripts": {
-      "version": "git+ssh://git@github.com/brave/brave-site-specific-scripts.git#4e7e0fc2dc89db5f7a690f3d237d65dc94ad79f7",
-      "from": "brave-site-specific-scripts@github:brave/brave-site-specific-scripts",
-      "requires": {
-        "@types/chrome": "0.0.100"
       }
     },
     "browser-level": {
@@ -9959,11 +9895,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "recursive-readdir-sync": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz",
-      "integrity": "sha1-Hb9tMvPFu4083pemxYjVR6nhPVY="
     },
     "reflect.getprototypeof": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
     "@mongodb-js/zstd": "^1.2.0",
     "@sentry/node": "7.120.3",
     "adblock-rs": "0.9.8",
-    "brave-site-specific-scripts": "github:brave/brave-site-specific-scripts",
     "p3a-config": "github:brave/p3a-config",
     "p3a-config-staging": "github:brave/p3a-config#staging",
     "pbf": "4.0.1",
     "playlist-component": "github:brave/playlist-component",
-    "recursive-readdir-sync": "1.0.6",
     "unzip-crx-3": "0.2.0"
   },
   "devDependencies": {
@@ -30,7 +28,7 @@
     "clean": "rimraf build/",
     "test": "node --test test/*.js scripts/**/*.test.js lib/*.test.js",
     "data-files-ad-block-rust": "node scripts/generateAdBlockRustDataFiles.js",
-    "data-files-local-data-files": "npm install --prefix ./node_modules/brave-site-specific-scripts && npm run --prefix ./node_modules/brave-site-specific-scripts build && mkdir -p brave-lists && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/clean-urls.json -O brave-lists/clean-urls.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/clean-urls-permissions.json -O brave-lists/clean-urls-permissions.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/debounce.json -O brave-lists/debounce.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/request-otr.json -O brave-lists/request-otr.json && wget https://https-upgrade-exceptions.s3.us-west-1.amazonaws.com/https-upgrade-exceptions-list.txt -O brave-lists/https-upgrade-exceptions-list.txt && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/localhost-permission-allow-list.txt -O brave-lists/localhost-permission-allow-list.txt && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/webcompat-exceptions.json -O brave-lists/webcompat-exceptions.json",
+    "data-files-local-data-files": "mkdir -p brave-lists && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/clean-urls.json -O brave-lists/clean-urls.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/clean-urls-permissions.json -O brave-lists/clean-urls-permissions.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/debounce.json -O brave-lists/debounce.json && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/request-otr.json -O brave-lists/request-otr.json && wget https://https-upgrade-exceptions.s3.us-west-1.amazonaws.com/https-upgrade-exceptions-list.txt -O brave-lists/https-upgrade-exceptions-list.txt && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/localhost-permission-allow-list.txt -O brave-lists/localhost-permission-allow-list.txt && wget https://raw.githubusercontent.com/brave/adblock-lists/master/brave-lists/webcompat-exceptions.json -O brave-lists/webcompat-exceptions.json",
     "data-files-leo-local-models": "mkdir -p leo-local-models && wget https://raw.githubusercontent.com/brave/leo-local-models/main/tflite_models/universal_sentence_encoder_qa_with_metadata_v1.tflite -O leo-local-models/universal_sentence_encoder_qa_with_metadata.tflite",
     "data-files-p3a-config": "npm update p3a-config && npm install --prefix ./node_modules/p3a-config && npm run --prefix ./node_modules/p3a-config build",
     "data-files-p3a-config-staging": "npm update p3a-config-staging && npm install --prefix ./node_modules/p3a-config-staging && npm run --prefix ./node_modules/p3a-config-staging build",

--- a/scripts/packageLocalDataFiles.js
+++ b/scripts/packageLocalDataFiles.js
@@ -7,9 +7,7 @@
 
 import commander from 'commander'
 import fs from 'fs-extra'
-import { mkdirp } from 'mkdirp'
 import path from 'path'
-import recursive from 'recursive-readdir-sync'
 import util from '../lib/util.js'
 
 const getOriginalManifest = () => {
@@ -27,19 +25,7 @@ const stageFiles = (version, outputDir) => {
     { path: path.join('brave-lists', 'clean-urls-permissions.json'), outputName: path.join(datFileVersion, 'clean-urls-permissions.json') },
     { path: path.join('brave-lists', 'https-upgrade-exceptions-list.txt'), outputName: path.join(datFileVersion, 'https-upgrade-exceptions-list.txt') },
     { path: path.join('brave-lists', 'localhost-permission-allow-list.txt'), outputName: path.join(datFileVersion, 'localhost-permission-allow-list.txt') }
-  ].concat(
-    recursive(path.join('node_modules', 'brave-site-specific-scripts', 'dist')).map(f => {
-      let outputDatDir = datFileVersion
-      const index = f.indexOf('/dist/')
-      let baseDir = f.substring(index + '/dist/'.length)
-      baseDir = baseDir.substring(0, baseDir.lastIndexOf('/'))
-      outputDatDir = path.join(outputDatDir, baseDir)
-      mkdirp.sync(path.join(outputDir, outputDatDir))
-      return {
-        path: f,
-        outputName: path.join(outputDatDir, path.parse(f).base)
-      }
-    }))
+  ]
   util.stageFiles(files, version, outputDir)
 }
 


### PR DESCRIPTION
For https://github.com/brave/devops/issues/13097

As of brave-core 1.74.x (released January 2025), `brave-site-specific-scripts` is no longer used by the browser.