### PR TITLE
Added retries for download external extensions.

### DIFF
--- a/scripts/packageManifestV2Extensions.js
+++ b/scripts/packageManifestV2Extensions.js
@@ -11,7 +11,7 @@ import glob from 'glob'
 import util from '../lib/util.js'
 import crx from '../lib/crx.js'
 
-const downloadExtension = async (config) => {
+const downloadExtensionInternal = async (config) => {
   const buildPath = path.join('build', config.name)
   const download = path.join(buildPath, 'download')
   const unpacked = path.join(buildPath, 'unpacked')
@@ -56,6 +56,21 @@ const downloadExtension = async (config) => {
   return {
     unpacked: findRoot(unpacked),
     sha256: sourceHash
+  }
+}
+
+const downloadExtension = async (config) => {
+  const maxAttempts = 3
+  for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
+    try {
+      return await downloadExtensionInternal(config)
+    } catch (error) {
+      if (attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, 5000 * attempt))
+      } else {
+        throw error
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Since we download extension from an external source, there can be failures ([example](https://ci.brave.com/job/brave-core-ext-manifest-v2-publish/78/console)), in this PR I've added the retry logic, it attempts to download extension 3 times with with 0s, 5s, 10s delay.