### PR TITLE
Sign mv2 extensions with publisher keys to allow Browser updates them.

### DIFF
--- a/scripts/packageManifestV2Extensions.js
+++ b/scripts/packageManifestV2Extensions.js
@@ -73,6 +73,8 @@ const packageV2Extension = (
   endpoint,
   region,
   keysDir,
+  publisherKey,
+  publisherAltKey,
   verifiedContentsKey,
   localRun
 ) => {
@@ -98,7 +100,12 @@ const packageV2Extension = (
     }
     const extensionKeyFile = path.join(keysDir, `${extensionName}-key.pem`)
     crx
-      .generateCrx(sources.unpacked, extensionKeyFile, [], verifiedContentsKey)
+      .generateCrx(
+        sources.unpacked,
+        extensionKeyFile,
+        [publisherKey, publisherAltKey],
+        verifiedContentsKey
+      )
       .then((extension) => {
         if (id !== util.getIDFromBase64PublicKey(extension.manifest.key)) {
           throw new Error(`${extensionName} invalid extension key used.`)
@@ -157,6 +164,8 @@ if (!commander.localRun) {
         commander.endpoint,
         commander.region,
         keysDir,
+        commander.publisherProofKey,
+        commander.publisherProofKeyAlt,
         commander.verifiedContentsKey
       )
     })
@@ -168,6 +177,8 @@ if (!commander.localRun) {
       commander.endpoint,
       commander.region,
       keysDir,
+      commander.publisherProofKey,
+      commander.publisherProofKeyAlt,
       commander.verifiedContentsKey,
       commander.localRun
     )


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/49198

The extension installer doesn't  require the publisher key because it relies on the verified contents (which is signed with another key), but the crx updater requires it because it's only relies on the publisher key and doesn't verify the verified contents (updater just unpacks it into the extension's directory).
