### PR TITLE
temporary fix for experimental adblock list scriptlets

### DIFF
--- a/scripts/generateAdBlockRustDataFiles.js
+++ b/scripts/generateAdBlockRustDataFiles.js
@@ -41,7 +41,7 @@ const getOutPath = (outputFilename, outSubdir) => {
 
 // Removes Brave-specific scriptlet injections from non-Brave lists
 const enforceBraveDirectives = (title, data) => {
-  if (!title || !title.startsWith('Brave ')) {
+  if (!title || !(title.startsWith('Brave ') || title === 'Experimental ad blocker')) { // TODO use github org name
     return data.split('\n').filter(line => {
       const hasBraveScriptlet = line.indexOf('+js(brave-') >= 0
       if (hasBraveScriptlet) {


### PR DESCRIPTION
Experimental list hasn't supported `brave-` scriptlets since its name was updated; see https://bravesoftware.slack.com/archives/C0AJ5QTAX0F/p1777521359349399?thread_ts=1777254325.155289&cid=C0AJ5QTAX0F