### PR TITLE
fix: reduce parallelisation on crx upload

### DIFF
--- a/scripts/uploadComponent.js
+++ b/scripts/uploadComponent.js
@@ -6,6 +6,7 @@ import commander from 'commander'
 import fs from 'fs'
 import path from 'path'
 import util from '../lib/util.js'
+import pAll from 'p-all'
 
 util.installErrorHandlers()
 
@@ -30,14 +31,14 @@ const uploadJobs = []
 if (fs.lstatSync(crxParam).isDirectory()) {
   fs.readdirSync(crxParam).forEach(file => {
     if (path.parse(file).ext === '.crx') {
-      uploadJobs.push(util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file)))
+      uploadJobs.push(() => util.uploadCRXFile(commander.endpoint, commander.region, path.join(crxParam, file)))
     }
   })
 } else {
-  uploadJobs.push(util.uploadCRXFile(commander.endpoint, commander.region, crxParam))
+  uploadJobs.push(() => util.uploadCRXFile(commander.endpoint, commander.region, crxParam))
 }
 
-Promise.all(uploadJobs).then(() => {
+pAll(uploadJobs, { concurrency: 5 }).then(() => {
   util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
     if (fs.lstatSync(crxParam).isDirectory()) {
       fs.readdirSync(crxParam).forEach(file => {


### PR DESCRIPTION
Similar to https://github.com/brave/brave-core-crx-packager/pull/1184, we encountered an error on dev where the CRX uploads failed with a timeout.  In this case it was trying to upload hundreds of CRXs and all of their generated puff patches in parallel.

See https://bravesoftware.slack.com/archives/CG08GKTFS/p1778146014739169 and the failing build https://ci.brave.com/job/brave-core-ext-ntp-sponsored-publish-dev/601.

Reduce the level of parallelisation on upload too.