### PR TITLE
Migrate from brave-wallet-lists to @brave/wallet-lists package

### DIFF
--- a/scripts/packageWalletDataFiles.js
+++ b/scripts/packageWalletDataFiles.js
@@ -17,7 +17,7 @@ const stageFiles = (version, outputDir) => {
 }
 
 const getPackageDir = () => {
-  return path.join('node_modules', 'brave-wallet-lists')
+  return path.join('node_modules', '@brave', 'wallet-lists')
 }
 
 const getOriginalManifest = () => {


### PR DESCRIPTION
We've migrated from [`brave-wallet-lists`](https://www.npmjs.com/package/brave-wallet-lists) to [**`@brave/wallet-lists`**](https://www.npmjs.com/package/@brave/wallet-lists) for better security, so this needs to be reflected in the crx packager.

Relates to https://github.com/brave/devops/issues/15978