### PR TITLE
Remove scriptlet dependency bundling and template arg wrapper

### DIFF
--- a/lib/adBlockRustUtils.js
+++ b/lib/adBlockRustUtils.js
@@ -6,6 +6,8 @@ import { promises as fs } from 'fs'
 
 import { compress } from '@mongodb-js/zstd'
 
+import Sentry from '../lib/sentry.js'
+
 const uBlockLocalRoot = 'submodules/uBlock'
 const uBlockWebAccessibleResources = path.join(uBlockLocalRoot, 'src/web_accessible_resources')
 const uBlockRedirectEngine = path.join(uBlockLocalRoot, 'src/js/redirect-resources.js')
@@ -60,53 +62,36 @@ const getRegionalLists = () => getListCatalog().then(catalog => {
   return catalog.filter(entry => !isDefaultList(entry))
 })
 
-// Wraps new template scriptlets with the older "numbered template arg" format and any required dependency code
-const wrapScriptletArgFormat = (fnString, dependencyPrelude) => `{
-  const args = ["{{1}}", "{{2}}", "{{3}}", "{{4}}", "{{5}}", "{{6}}", "{{7}}", "{{8}}", "{{9}}"];
-  let last_arg_index = 0;
-  for (const arg_index in args) {
-    if (args[arg_index] === '{{' + (Number(arg_index) + 1) + '}}') {
-      break;
-    }
-    last_arg_index += 1;
-  }
-  ${dependencyPrelude}
-  (${fnString})(...args.slice(0, last_arg_index))
-}`
-
 const generateResources = lazyInit(async () => {
   const { builtinScriptlets } = await import(path.join('..', uBlockScriptlets).toString())
 
+  // Confirm all required dependencies exist
   const dependencyMap = builtinScriptlets.reduce((map, entry) => {
-    map[entry.name] = entry
+    map.set(entry.name, entry)
     return map
-  }, {})
-
-  const transformedUboBuiltins = builtinScriptlets.filter(s => !s.name.endsWith('.fn')).map(s => {
-    // Bundle dependencies wherever needed. This causes some small duplication but makes each scriptlet fully self-contained.
-    let dependencyPrelude = ''
-    const requiredDependencies = s.dependencies ?? []
-    for (const dep of requiredDependencies) {
-      for (const recursiveDep of dependencyMap[dep].dependencies ?? []) {
-        if (!requiredDependencies.includes(recursiveDep)) {
-          requiredDependencies.push(recursiveDep)
+  }, new Map())
+  for (const [depName, entry] of dependencyMap.entries()) {
+    for (const recursiveDep of entry.dependencies ?? []) {
+      if (!dependencyMap.has(recursiveDep)) {
+        const warning = `uBO scriptlet ${depName} is missing dependency ${recursiveDep.name}`
+        console.log(warning)
+        if (Sentry) {
+          Sentry.captureException(warning, { level: 'warning' })
         }
       }
     }
-    for (const dep of requiredDependencies.reverse()) {
-      const thisDepCode = dependencyMap[dep].fn.toString()
-      if (thisDepCode === undefined) {
-        throw new Error(`Couldn't find dependency ${dep}`)
-      }
-      dependencyPrelude += thisDepCode + '\n'
-    }
-    const content = Buffer.from(wrapScriptletArgFormat(s.fn.toString(), dependencyPrelude)).toString('base64')
+  }
+
+  const transformedUboBuiltins = builtinScriptlets.map(s => {
+    const dependencies = s.dependencies ?? []
+    const content = Buffer.from(s.fn.toString()).toString('base64')
     // in Brave Browser, bit 0 (i.e. 1 << 0) signifies uBO resource permission.
     return {
       name: s.name,
       aliases: s.aliases ?? [],
       kind: { mime: 'application/javascript' },
-      content
+      content,
+      dependencies
     }
   })
 


### PR DESCRIPTION
The workarounds being removed here were added to maintain compatibility with old versions of the browser as breaking changes appeared in upstream uBlock Origin scriptlets.

See https://github.com/brave/brave-core-crx-packager/pull/599 - all changes are merged as of Brave v1.50.x for iOS and Desktop, which was in April 2023 (over 3 years ago).

The browser-native support should be old enough now to safely remove the workarounds.

The resulting `resources.json` has been tested on:
- [x] Desktop
- [x] Android
- [x] iOS