### PR TITLE
[PSST] Create PSST CRX component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ leo-local-models
 # localstack
 .localstack/
 .vscode/
+
+# Psst scripts folder for data-files-brave-psst
+psst-component

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/uBlock"]
 	path = submodules/uBlock
 	url = https://github.com/brave/uBlock
+[submodule "submodules/psst"]
+	path = submodules/psst
+	url = https://github.com/brave-experiments/psst-component

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "submodules/uBlock"]
 	path = submodules/uBlock
 	url = https://github.com/brave/uBlock
-[submodule "submodules/psst"]
-	path = submodules/psst
-	url = https://github.com/brave/psst-component

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/brave/uBlock
 [submodule "submodules/psst"]
 	path = submodules/psst
-	url = https://github.com/brave-experiments/psst-component
+	url = https://github.com/brave/psst-component

--- a/manifests/psst/default-manifest.json
+++ b/manifests/psst/default-manifest.json
@@ -1,7 +1,7 @@
 {
-  "description": "Brave Privacy Settings Selection for Sites Tool (PSSST) Files",
+  "description": "Brave Privacy Settings Selection for Sites Tool (PSST) Files",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz7OnL/yxxX0a/IKLJc2LCQ5k12S6uQFuSCkruf7mGLuDhepKo8lA5orJQI8dqUMivTmxXC7SWYVS9uj05b9LTcLtmlcNiUjdYFoCzmdtRh6rBTCzTZ7wkyyhacUpY7N3BRIR5dRk1OLfx2ovm8BLQqak3YJ7dsPxD29714xPlbaMXDCsXEgibaGlXSNpDuCKFtzhVuRhSD6hRRQ7OgLQ7vm0b5BECO/jRuMHra4G4S9Z0rRN8KA9dC38t55O+FeOGZMhjJzBEJPk5AlQzlbPGq/MVPUu+4XFNEUoaeu65PjoAc05apRFCQQ/lcNy5gQfzwVExTNyrdP62eoRf+ANhQIDAQAB",
   "manifest_version": 2,
-  "name": "Brave Privacy Settings Selection for Sites Tool (PSSST) Files",
+  "name": "Brave Privacy Settings Selection for Sites Tool (PSST) Files",
   "version": "0.0.0"
 }

--- a/manifests/psst/default-manifest.json
+++ b/manifests/psst/default-manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave Privacy Settings Selection for Sites Tool (PSSST) Files",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz7OnL/yxxX0a/IKLJc2LCQ5k12S6uQFuSCkruf7mGLuDhepKo8lA5orJQI8dqUMivTmxXC7SWYVS9uj05b9LTcLtmlcNiUjdYFoCzmdtRh6rBTCzTZ7wkyyhacUpY7N3BRIR5dRk1OLfx2ovm8BLQqak3YJ7dsPxD29714xPlbaMXDCsXEgibaGlXSNpDuCKFtzhVuRhSD6hRRQ7OgLQ7vm0b5BECO/jRuMHra4G4S9Z0rRN8KA9dC38t55O+FeOGZMhjJzBEJPk5AlQzlbPGq/MVPUu+4XFNEUoaeu65PjoAc05apRFCQQ/lcNy5gQfzwVExTNyrdP62eoRf+ANhQIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave Privacy Settings Selection for Sites Tool (PSSST) Files",
+  "version": "0.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "data-files-brave-user-agent": "mkdir -p brave-user-agent && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/brave-checks.txt -O brave-user-agent/brave-checks.txt",
     "data-files-query-filter": "mkdir -p query-filter && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/query-filter.json -O query-filter/query-filter.json",
     "data-files-playlist-exclusions": "mkdir -p playlist-exclusions && wget https://raw.githubusercontent.com/brave/playlist-component/refs/heads/main/playlist_exclusions.json -O playlist-exclusions/playlist_exclusions.json",
-    "data-files-brave-psst": "node ./scripts/dataFilesBravePsst.js",
+    "data-files-brave-psst": "node scripts/dataFilesBravePsst.js",
     "generate-ad-block-manifests": "node scripts/generateManifestForRustAdblock.js",
     "generate-ntp-background-images": "node scripts/generateNTPBackgroundImages.js",
     "generate-ntp-sponsored-images": "node scripts/ntp-sponsored-images/generate",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "data-files-brave-user-agent": "mkdir -p brave-user-agent && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/brave-checks.txt -O brave-user-agent/brave-checks.txt",
     "data-files-query-filter": "mkdir -p query-filter && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/query-filter.json -O query-filter/query-filter.json",
     "data-files-playlist-exclusions": "mkdir -p playlist-exclusions && wget https://raw.githubusercontent.com/brave/playlist-component/refs/heads/main/playlist_exclusions.json -O playlist-exclusions/playlist_exclusions.json",
+    "data-files-brave-psst": "npm install --prefix ./submodules/psst && npm run --prefix ./submodules/psst bundle:dev",
     "generate-ad-block-manifests": "node scripts/generateManifestForRustAdblock.js",
     "generate-ntp-background-images": "node scripts/generateNTPBackgroundImages.js",
     "generate-ntp-sponsored-images": "node scripts/ntp-sponsored-images/generate",
@@ -56,6 +57,7 @@
     "package-manifest-v2-extensions": "node ./scripts/packageManifestV2Extensions",
     "package-query-filter": "node ./scripts/packageQueryFilterComponent.js",
     "package-playlist-exclusions": "node ./scripts/packagePlaylistExclusionsComponent.js",
+    "package-brave-psst": "node ./scripts/packageBravePsstComponent.js",
     "generate-puffpatches": "node ./scripts/generatePuffpatches",
     "upload-component": "node ./scripts/uploadComponent"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "data-files-brave-user-agent": "mkdir -p brave-user-agent && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/brave-checks.txt -O brave-user-agent/brave-checks.txt",
     "data-files-query-filter": "mkdir -p query-filter && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/query-filter.json -O query-filter/query-filter.json",
     "data-files-playlist-exclusions": "mkdir -p playlist-exclusions && wget https://raw.githubusercontent.com/brave/playlist-component/refs/heads/main/playlist_exclusions.json -O playlist-exclusions/playlist_exclusions.json",
-    "data-files-brave-psst": "npm install --prefix ./submodules/psst && npm run --prefix ./submodules/psst bundle:dev",
+    "data-files-brave-psst": "node ./scripts/dataFilesBravePsst.js",
     "generate-ad-block-manifests": "node scripts/generateManifestForRustAdblock.js",
     "generate-ntp-background-images": "node scripts/generateNTPBackgroundImages.js",
     "generate-ntp-sponsored-images": "node scripts/ntp-sponsored-images/generate",

--- a/scripts/dataFilesBravePsst.js
+++ b/scripts/dataFilesBravePsst.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Installs the PSST submodule dependencies and bundles it.
+//
+// Example usage:
+//  npm run data-files-brave-psst          (defaults to dev)
+//  npm run data-files-brave-psst dev
+//  npm run data-files-brave-psst prod
+
+import { execSync } from 'child_process'
+
+const mode = (process.argv[2] || 'dev').toLowerCase()
+
+if (mode !== 'dev' && mode !== 'prod') {
+  console.error(`Invalid mode "${mode}". Expected "dev" or "prod".`)
+  process.exit(1)
+}
+
+const psstPrefix = './submodules/psst'
+
+execSync('npm install --prefix ' + psstPrefix, { stdio: 'inherit' })
+execSync(`npm run --prefix ${psstPrefix} bundle:${mode}`, { stdio: 'inherit' })

--- a/scripts/dataFilesBravePsst.js
+++ b/scripts/dataFilesBravePsst.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Installs the PSST submodule dependencies and bundles it.
+// Checks out the latest revision of the psst-component repository (main branch),
+// installs its dependencies, and bundles it.
 //
 // Example usage:
 //  npm run data-files-brave-psst          (defaults to dev)
@@ -10,6 +11,7 @@
 //  npm run data-files-brave-psst prod
 
 import { execSync } from 'child_process'
+import { existsSync } from 'fs'
 
 const mode = (process.argv[2] || 'dev').toLowerCase()
 
@@ -18,7 +20,17 @@ if (mode !== 'dev' && mode !== 'prod') {
   process.exit(1)
 }
 
-const psstPrefix = './submodules/psst'
+const psstPrefix = './psst-component'
+const psstRepo = 'git@github.com:brave/psst-component.git'
 
-execSync('npm install --prefix ' + psstPrefix, { stdio: 'inherit' })
+if (existsSync(psstPrefix)) {
+  // Repo already cloned — fetch and reset to latest main
+  execSync(`git -C ${psstPrefix} fetch origin main`, { stdio: 'inherit' })
+  execSync(`git -C ${psstPrefix} reset --hard origin/main`, { stdio: 'inherit' })
+} else {
+  // Fresh clone
+  execSync(`git clone --branch main --depth 1 ${psstRepo} ${psstPrefix}`, { stdio: 'inherit' })
+}
+
+execSync(`npm install --prefix ${psstPrefix}`, { stdio: 'inherit' })
 execSync(`npm run --prefix ${psstPrefix} bundle:${mode}`, { stdio: 'inherit' })

--- a/scripts/packageBravePsstComponent.js
+++ b/scripts/packageBravePsstComponent.js
@@ -12,8 +12,7 @@ import path from 'path'
 import util from '../lib/util.js'
 import ntpUtil from '../lib/ntpUtil.js'
 
-const psstSubmoduleDir = path.join(path.resolve(), 'submodules', 'psst')
-const psstOutputDir = path.join(psstSubmoduleDir, 'out')
+const psstOutputDir = path.join(path.resolve(), 'psst-component', 'out')
 
 const getOriginalManifest = () => {
   return path.join(path.resolve(), 'manifests', 'psst', 'default-manifest.json')

--- a/scripts/packageBravePsstComponent.js
+++ b/scripts/packageBravePsstComponent.js
@@ -19,43 +19,10 @@ const getOriginalManifest = () => {
   return path.join(path.resolve(), 'manifests', 'psst', 'default-manifest.json')
 }
 
-const stageFiles = (version, outputDir) => {
-  // psst.json lists every supported website along with the relative names of
-  // its generated user/policy scripts; stage each one alongside the config.
-  const psstConfigPath = path.join(psstOutputDir, 'psst.json')
-  const psstConfig = JSON.parse(fs.readFileSync(psstConfigPath, 'utf8'))
-
-  const files = [
-    { path: getOriginalManifest(), outputName: 'manifest.json' },
-    { path: psstConfigPath, outputName: 'psst.json' }
-  ]
-
-  for (const entry of psstConfig) {
-    const scriptDir = path.join('scripts', entry.name)
-    files.push({
-      path: path.join(psstOutputDir, scriptDir, entry.user_script),
-      outputName: path.join(scriptDir, entry.user_script)
-    })
-    files.push({
-      path: path.join(psstOutputDir, scriptDir, entry.policy_script),
-      outputName: path.join(scriptDir, entry.policy_script)
-    })
-  }
-
-  util.stageFiles(files, version, outputDir)
-}
-
-const generateManifestFile = (publicKey) => {
-  const manifestFile = getOriginalManifest()
-  const manifestContent = {
-    description: 'Brave Privacy Settings Selection for Sites Tool (PSSST) component',
-    key: publicKey,
-    manifest_version: 2,
-    name: 'Brave Privacy Settings Selection for Sites Tool (PSSST)',
-    version: '0.0.0'
-  }
-  fs.writeFileSync(manifestFile, JSON.stringify(manifestContent))
-}
+const stageFiles = util.stageDir.bind(
+  undefined,
+  path.join(psstOutputDir),
+  getOriginalManifest())
 
 const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
   publisherProofKey, publisherProofKeyAlt) => {
@@ -85,8 +52,7 @@ if (commander.keyFile && fs.existsSync(commander.keyFile)) {
 }
 
 util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
-  const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
-  generateManifestFile(publicKey)
+  const [, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
   generateCRXFile(commander.binary, commander.endpoint, commander.region,
     componentID, privateKeyFile, commander.publisherProofKey, commander.publisherProofKeyAlt)
 })

--- a/scripts/packageBravePsstComponent.js
+++ b/scripts/packageBravePsstComponent.js
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+//  npm run package-brave-psst -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/brave-psst.pem
+
+import commander from 'commander'
+import { execSync } from 'child_process'
+import fs from 'fs-extra'
+import { mkdirp } from 'mkdirp'
+import path from 'path'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
+
+const psstSubmoduleDir = path.join(path.resolve(), 'submodules', 'psst')
+const psstOutputDir = path.join(psstSubmoduleDir, 'out')
+
+const getOriginalManifest = () => {
+  return path.join(path.resolve(), 'manifests', 'psst', 'default-manifest.json')
+}
+
+// Build the PSST submodule. `npm run bundle:dev` first generates out/psst.json
+// (the prebundle step) and then bundles each website's scripts to
+// out/scripts/<website>/{user.js,policy.js} via webpack.
+const buildPsstSubmodule = () => {
+  console.log('Building PSST submodule...')
+  execSync('npm run bundle:dev', {
+    cwd: psstSubmoduleDir,
+    stdio: 'inherit'
+  })
+}
+
+const stageFiles = (version, outputDir) => {
+  buildPsstSubmodule()
+
+  // psst.json lists every supported website along with the relative names of
+  // its generated user/policy scripts; stage each one alongside the config.
+  const psstConfigPath = path.join(psstOutputDir, 'psst.json')
+  const psstConfig = JSON.parse(fs.readFileSync(psstConfigPath, 'utf8'))
+
+  const files = [
+    { path: getOriginalManifest(), outputName: 'manifest.json' },
+    { path: psstConfigPath, outputName: 'psst.json' }
+  ]
+
+  for (const entry of psstConfig) {
+    const scriptDir = path.join('scripts', entry.name)
+    files.push({
+      path: path.join(psstOutputDir, scriptDir, entry.user_script),
+      outputName: path.join(scriptDir, entry.user_script)
+    })
+    files.push({
+      path: path.join(psstOutputDir, scriptDir, entry.policy_script),
+      outputName: path.join(scriptDir, entry.policy_script)
+    })
+  }
+
+  util.stageFiles(files, version, outputDir)
+}
+
+const generateManifestFile = (publicKey) => {
+  const manifestFile = getOriginalManifest()
+  const manifestContent = {
+    description: 'Brave Privacy Settings Selection for Sites Tool (PSSST) component',
+    key: publicKey,
+    manifest_version: 2,
+    name: 'Brave Privacy Settings Selection for Sites Tool (PSSST)',
+    version: '0.0.0'
+  }
+  fs.writeFileSync(manifestFile, JSON.stringify(manifestContent))
+}
+
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+  publisherProofKey, publisherProofKeyAlt) => {
+  const stagingDir = path.join('build', 'psst')
+  const crxFile = path.join(stagingDir, 'psst.crx')
+  mkdirp.sync(stagingDir)
+  util.getNextVersion(endpoint, region, componentID).then((version) => {
+    stageFiles(version, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+      publisherProofKeyAlt, stagingDir)
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+util.installErrorHandlers()
+
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key-file <file>', 'file containing private key for signing crx file'))
+  .parse(process.argv)
+
+let privateKeyFile = ''
+if (fs.existsSync(commander.keyFile)) {
+  privateKeyFile = commander.keyFile
+} else {
+  throw new Error('Missing or invalid private key')
+}
+
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  const [publicKey, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
+  generateManifestFile(publicKey)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+    componentID, privateKeyFile, commander.publisherProofKey, commander.publisherProofKeyAlt)
+})

--- a/scripts/packageBravePsstComponent.js
+++ b/scripts/packageBravePsstComponent.js
@@ -6,7 +6,6 @@
 //  npm run package-brave-psst -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/brave-psst.pem
 
 import commander from 'commander'
-import { execSync } from 'child_process'
 import fs from 'fs-extra'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
@@ -20,20 +19,7 @@ const getOriginalManifest = () => {
   return path.join(path.resolve(), 'manifests', 'psst', 'default-manifest.json')
 }
 
-// Build the PSST submodule. `npm run bundle:dev` first generates out/psst.json
-// (the prebundle step) and then bundles each website's scripts to
-// out/scripts/<website>/{user.js,policy.js} via webpack.
-const buildPsstSubmodule = () => {
-  console.log('Building PSST submodule...')
-  execSync('npm run bundle:dev', {
-    cwd: psstSubmoduleDir,
-    stdio: 'inherit'
-  })
-}
-
 const stageFiles = (version, outputDir) => {
-  buildPsstSubmodule()
-
   // psst.json lists every supported website along with the relative names of
   // its generated user/policy scripts; stage each one alongside the config.
   const psstConfigPath = path.join(psstOutputDir, 'psst.json')

--- a/scripts/packageBravePsstComponent.js
+++ b/scripts/packageBravePsstComponent.js
@@ -78,7 +78,7 @@ util.addCommonScriptOptions(
   .parse(process.argv)
 
 let privateKeyFile = ''
-if (fs.existsSync(commander.keyFile)) {
+if (commander.keyFile && fs.existsSync(commander.keyFile)) {
   privateKeyFile = commander.keyFile
 } else {
   throw new Error('Missing or invalid private key')


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/56434

Adds new PSST CRX Component packaging.

Component ID: `bchfnigamfmpeanhekjggkphjfobpipo`

This will need a new Jenkins job as well.

PEM is uploaded to 1Password Developers Shared in `Brave PSST Component`.

Common flow is next:
1. First we need to prepare data for packaging, it can be don with one of the next commands:
`npm run data-files-brave-psst `         (defaults to dev)
`npm run data-files-brave-psst dev`
`npm run data-files-brave-psst prod`

`dev` - means that result js scripts will not be minimized, so it make sense to use `dev` for PR developer builds
In other case use `prod`. Note: if possible it would be nice to have an ability to set `dev` or `prod on the developer environment by hand`

2. Then we can execute packaging:
`npm run package-brave-psst`