### PR TITLE
prevent path traversals from remotely controlled filenames

### DIFF
--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -46,8 +46,13 @@ const validateTargetPath = (rootPath, targetPath) => {
   const resolvedRoot = path.resolve(rootPath)
   const resolvedTarget = path.resolve(targetPath)
 
-  if (resolvedTarget !== resolvedRoot &&
-      !resolvedTarget.startsWith(resolvedRoot + path.sep)) {
+  // Require the target to be the root itself or sit beneath it. Append a
+  // separator to reject sibling-prefix escapes (e.g. "<root>-evil"), unless
+  // the root already ends with one (e.g. a filesystem root such as "/").
+  const rootWithSep = resolvedRoot.endsWith(path.sep)
+    ? resolvedRoot
+    : resolvedRoot + path.sep
+  if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(rootWithSep)) {
     throw new Error(`path ${targetPath} traverses outside of root ${rootPath}`)
   }
 }

--- a/lib/ntpUtil.js
+++ b/lib/ntpUtil.js
@@ -46,7 +46,8 @@ const validateTargetPath = (rootPath, targetPath) => {
   const resolvedRoot = path.resolve(rootPath)
   const resolvedTarget = path.resolve(targetPath)
 
-  if (!resolvedTarget.startsWith(resolvedRoot)) {
+  if (resolvedTarget !== resolvedRoot &&
+      !resolvedTarget.startsWith(resolvedRoot + path.sep)) {
     throw new Error(`path ${targetPath} traverses outside of root ${rootPath}`)
   }
 }

--- a/lib/ntpUtil.test.js
+++ b/lib/ntpUtil.test.js
@@ -18,3 +18,21 @@ test('should validate path does not traverse outside of target', () => {
     ntpUtil.validateTargetPath(rootDir, path.join(rootDir, '../file.json')),
   /path file.json traverses outside of root/)
 })
+
+// Regression: the previous `startsWith(resolvedRoot)` check would incorrectly
+// allow a sibling directory that shares the root as a string prefix.
+test('should reject sibling directories sharing the root prefix', () => {
+  const rootDir = path.resolve(fs.mkdtempSync('ntp-util-test'))
+
+  assert.throws(() =>
+    ntpUtil.validateTargetPath(rootDir, rootDir + '-evil/payload'),
+  /traverses outside of root/)
+})
+
+// Edge case: a filesystem root already ends with a separator, so appending
+// another separator must not reject valid targets beneath it.
+test('should allow targets under a filesystem-root root path', () => {
+  const fsRoot = path.resolve('/')
+
+  ntpUtil.validateTargetPath(fsRoot, path.join(fsRoot, 'anything'))
+})

--- a/lib/ntpUtil.test.js
+++ b/lib/ntpUtil.test.js
@@ -24,9 +24,13 @@ test('should validate path does not traverse outside of target', () => {
 test('should reject sibling directories sharing the root prefix', () => {
   const rootDir = path.resolve(fs.mkdtempSync('ntp-util-test'))
 
-  assert.throws(() =>
-    ntpUtil.validateTargetPath(rootDir, rootDir + '-evil/payload'),
-  /traverses outside of root/)
+  try {
+    assert.throws(() =>
+      ntpUtil.validateTargetPath(rootDir, rootDir + '-evil/payload'),
+    /traverses outside of root/)
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
 })
 
 // Edge case: a filesystem root already ends with a separator, so appending

--- a/scripts/generateBraveAdsResourcesComponentInputFiles.js
+++ b/scripts/generateBraveAdsResourcesComponentInputFiles.js
@@ -6,6 +6,7 @@ import path from 'path'
 import { mkdirp } from 'mkdirp'
 import fs from 'fs-extra'
 import commander from 'commander'
+import ntpUtil from '../lib/ntpUtil.js'
 import { Readable } from 'stream'
 import { finished } from 'stream/promises'
 
@@ -77,55 +78,45 @@ const getComponentList = () => {
   ]
 }
 
-function downloadComponentInputFiles (manifestFileName, manifestUrl, outDir) {
-  return new Promise(function (resolve, reject) {
-    let manifestBody = '{}'
-    fetch(manifestUrl).then(async function (response) {
-      if (response.status === 200) {
-        manifestBody = await response.text()
-      }
+async function downloadComponentInputFiles (manifestFileName, manifestUrl, outDir) {
+  let manifestBody = '{}'
+  try {
+    const response = await fetch(manifestUrl)
+    if (response.status === 200) {
+      manifestBody = await response.text()
+    }
 
-      const manifestJson = JSON.parse(manifestBody)
-      if (!manifestJson.schemaVersion) {
-        const error = 'Error: Missing schema version'
-        console.error(error)
-        return reject(error)
-      }
+    const manifestJson = JSON.parse(manifestBody)
+    if (!manifestJson.schemaVersion) {
+      throw new Error('Missing schema version')
+    }
 
-      fs.writeFileSync(`${outDir}/${manifestFileName}`, JSON.stringify(manifestJson))
+    fs.writeFileSync(`${outDir}/${manifestFileName}`, JSON.stringify(manifestJson))
 
-      const fileList = []
+    const fileList = []
 
-      if (manifestJson.resources) {
-        manifestJson.resources.forEach((resource) => {
-          fileList.push(resource.filename)
-        })
-      }
-
-      const resolvedOutDir = path.resolve(outDir)
-      const downloadOps = fileList.map(async (fileName) => {
-        const resourceFileOutPath = path.join(outDir, fileName)
-        // Reject filenames that escape the output dir (path traversal),
-        // since fileName comes verbatim from the remote manifest.
-        const resolvedOutPath = path.resolve(resourceFileOutPath)
-        if (resolvedOutPath !== resolvedOutDir &&
-            !resolvedOutPath.startsWith(resolvedOutDir + path.sep)) {
-          throw new Error(`Refusing to write file outside output dir: ${fileName}`)
-        }
-        const resourceFileUrl = new URL(fileName, manifestUrl).href
-        const response = await fetch(resourceFileUrl)
-        const ws = fs.createWriteStream(resourceFileOutPath)
-        return finished(Readable.fromWeb(response.body).pipe(ws))
-          .then(() => console.log(resourceFileUrl))
+    if (manifestJson.resources) {
+      manifestJson.resources.forEach((resource) => {
+        fileList.push(resource.filename)
       })
+    }
 
-      await Promise.all(downloadOps)
-
-      resolve()
-    }).catch(error => {
-      throw new Error(`Error from ${manifestUrl}: ${error.cause}`)
+    const downloadOps = fileList.map(async (fileName) => {
+      const resourceFileOutPath = path.join(outDir, fileName)
+      // Reject filenames that escape the output dir (path traversal),
+      // since fileName comes verbatim from the remote manifest.
+      ntpUtil.validateTargetPath(outDir, resourceFileOutPath)
+      const resourceFileUrl = new URL(fileName, manifestUrl).href
+      const response = await fetch(resourceFileUrl)
+      const ws = fs.createWriteStream(resourceFileOutPath)
+      return finished(Readable.fromWeb(response.body).pipe(ws))
+        .then(() => console.log(resourceFileUrl))
     })
-  })
+
+    await Promise.all(downloadOps)
+  } catch (error) {
+    throw new Error(`Error from ${manifestUrl}`, { cause: error })
+  }
 }
 
 async function generateComponents (dataUrl) {

--- a/scripts/generateBraveAdsResourcesComponentInputFiles.js
+++ b/scripts/generateBraveAdsResourcesComponentInputFiles.js
@@ -91,7 +91,7 @@ async function downloadComponentInputFiles (manifestFileName, manifestUrl, outDi
       throw new Error('Missing schema version')
     }
 
-    fs.writeFileSync(`${outDir}/${manifestFileName}`, JSON.stringify(manifestJson))
+    fs.writeFileSync(path.join(outDir, manifestFileName), JSON.stringify(manifestJson))
 
     const fileList = []
 

--- a/scripts/generateBraveAdsResourcesComponentInputFiles.js
+++ b/scripts/generateBraveAdsResourcesComponentInputFiles.js
@@ -102,8 +102,16 @@ function downloadComponentInputFiles (manifestFileName, manifestUrl, outDir) {
         })
       }
 
+      const resolvedOutDir = path.resolve(outDir)
       const downloadOps = fileList.map(async (fileName) => {
         const resourceFileOutPath = path.join(outDir, fileName)
+        // Reject filenames that escape the output dir (path traversal),
+        // since fileName comes verbatim from the remote manifest.
+        const resolvedOutPath = path.resolve(resourceFileOutPath)
+        if (resolvedOutPath !== resolvedOutDir &&
+            !resolvedOutPath.startsWith(resolvedOutDir + path.sep)) {
+          throw new Error(`Refusing to write file outside output dir: ${fileName}`)
+        }
         const resourceFileUrl = new URL(fileName, manifestUrl).href
         const response = await fetch(resourceFileUrl)
         const ws = fs.createWriteStream(resourceFileOutPath)

--- a/scripts/generateNTPBackgroundImages.js
+++ b/scripts/generateNTPBackgroundImages.js
@@ -7,6 +7,7 @@ import { mkdirp } from 'mkdirp'
 import fs from 'fs-extra'
 import commander from 'commander'
 import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
 import { Readable } from 'stream'
 import { finished } from 'stream/promises'
 
@@ -74,17 +75,11 @@ async function prepareAssets (jsonFileUrl, targetResourceDir) {
 
   // Download image files that specified in jsonFileUrl
   const imageFileNameList = getImageFileNameListFrom(photoData)
-  const imageErrors = []
-  const resolvedResourceDir = path.resolve(targetResourceDir)
   const downloadOps = imageFileNameList.map(async (imageFileName) => {
     const targetImageFilePath = path.join(targetResourceDir, imageFileName)
     // Reject sources that escape the staging directory (path traversal),
     // since imageFileName comes verbatim from the remote photo.json.
-    const resolvedImagePath = path.resolve(targetImageFilePath)
-    if (resolvedImagePath !== resolvedResourceDir &&
-        !resolvedImagePath.startsWith(resolvedResourceDir + path.sep)) {
-      throw new Error(`Refusing to write image outside resource dir: ${imageFileName}`)
-    }
+    ntpUtil.validateTargetPath(targetResourceDir, targetImageFilePath)
     const targetImageFileUrl = new URL(imageFileName, jsonFileUrl).href
     const response = await util.s3capableFetch(targetImageFileUrl)
     const ws = fs.createWriteStream(targetImageFilePath)
@@ -92,10 +87,6 @@ async function prepareAssets (jsonFileUrl, targetResourceDir) {
     console.log(`Downloaded ${targetImageFileUrl}`)
   })
   await Promise.all(downloadOps)
-  if (imageErrors.length) {
-    imageErrors.forEach(e => console.error(e))
-    throw new Error('There were some image download errors. Aborting!')
-  }
 }
 
 async function generateNTPBackgroundImages (dataUrl) {

--- a/scripts/generateNTPBackgroundImages.js
+++ b/scripts/generateNTPBackgroundImages.js
@@ -75,8 +75,16 @@ async function prepareAssets (jsonFileUrl, targetResourceDir) {
   // Download image files that specified in jsonFileUrl
   const imageFileNameList = getImageFileNameListFrom(photoData)
   const imageErrors = []
+  const resolvedResourceDir = path.resolve(targetResourceDir)
   const downloadOps = imageFileNameList.map(async (imageFileName) => {
     const targetImageFilePath = path.join(targetResourceDir, imageFileName)
+    // Reject sources that escape the staging directory (path traversal),
+    // since imageFileName comes verbatim from the remote photo.json.
+    const resolvedImagePath = path.resolve(targetImageFilePath)
+    if (resolvedImagePath !== resolvedResourceDir &&
+        !resolvedImagePath.startsWith(resolvedResourceDir + path.sep)) {
+      throw new Error(`Refusing to write image outside resource dir: ${imageFileName}`)
+    }
     const targetImageFileUrl = new URL(imageFileName, jsonFileUrl).href
     const response = await util.s3capableFetch(targetImageFileUrl)
     const ws = fs.createWriteStream(targetImageFilePath)


### PR DESCRIPTION
not sure these are actually exploitable given what influence (if any) an attacker could have over the filenames, but in any case these build scripts wrote files to paths built by joining a target directory with a remotely-controlled filename, allowing '../' in the filename to escape the staging directory.