### PR TITLE
[AI Chat]: Add WebMCP component

### DIFF
--- a/manifests/web-mcp/default-manifest.json
+++ b/manifests/web-mcp/default-manifest.json
@@ -1,0 +1,7 @@
+{
+  "description": "Brave WebMCP Tool Scripts",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvX8cJN/GXZCwijNam8Pyqb+gFi2GJE+cN6cTfvDmToSEivqQ3SQkLZwyORIWKxxrWnopybF2MzUEOLoW1gPjGGGrZVExlcIpLHX0SitFqdfQDMOSdVD5OOJEvV/YOKyejmWjXcIAhj5/J8d+lAvHINCbQQXMvWvnzeo6BBcVrYh6sbg6yDAQ85aoANTDBIffjui8c+wSnfQdZ9B2gP4JRX48iDWYpE2z2Wk/q0hecXK4UQbn7BbZmWwChfJWL64E+BiGdBV1yhdzJHmXo+05wWPzFB2SjxUjXfnht+fgypeTwNGvBTFBM1qHu3VZ/+pZggjUIdMCXUKItqYI5fC8GwIDAQAB",
+  "manifest_version": 2,
+  "name": "Brave WebMCP Tool Scripts",
+  "version": "0.0.0"
+}

--- a/manifests/web-mcp/default-manifest.json
+++ b/manifests/web-mcp/default-manifest.json
@@ -1,6 +1,6 @@
 {
   "description": "Brave WebMCP Tool Scripts",
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvX8cJN/GXZCwijNam8Pyqb+gFi2GJE+cN6cTfvDmToSEivqQ3SQkLZwyORIWKxxrWnopybF2MzUEOLoW1gPjGGGrZVExlcIpLHX0SitFqdfQDMOSdVD5OOJEvV/YOKyejmWjXcIAhj5/J8d+lAvHINCbQQXMvWvnzeo6BBcVrYh6sbg6yDAQ85aoANTDBIffjui8c+wSnfQdZ9B2gP4JRX48iDWYpE2z2Wk/q0hecXK4UQbn7BbZmWwChfJWL64E+BiGdBV1yhdzJHmXo+05wWPzFB2SjxUjXfnht+fgypeTwNGvBTFBM1qHu3VZ/+pZggjUIdMCXUKItqYI5fC8GwIDAQAB",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1cs/q1SFnqEgbPFni1hTXJNDqzsfJJIzNoUNCD/vPwpgUH0nXvLAgagAyBcxFi3Y7rU3vidnXiFL7iPaikZN40nEfsfE/3FNaIaHPQa3xtmL76CqsAT21iYuEu+I3MZIqTNewC7XUqBh5rw1V0joVkQvHMpeKqUgIUhnxeqjQpoyL3GLR9d3P+f5g8V206dJUvXqUKc2Cc5tVYpSHIiIhh081fchkYwJ9Yszg3EIhCgnbaoONAHsjzfGsJTQ6IlgD2uyOdtQi4/wdlsWNvvlpqLNIVLTIyAy8QlCOTujvyey95CJPF2e/6LuIzkyKUaje/tFmyDD9xTTcpRSKMVY8QIDAQAB",
   "manifest_version": 2,
   "name": "Brave WebMCP Tool Scripts",
   "version": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "data-files-query-filter": "mkdir -p query-filter && wget https://raw.githubusercontent.com/brave/adblock-lists/refs/heads/master/brave-lists/query-filter.json -O query-filter/query-filter.json",
     "data-files-playlist-exclusions": "mkdir -p playlist-exclusions && wget https://raw.githubusercontent.com/brave/playlist-component/refs/heads/main/playlist_exclusions.json -O playlist-exclusions/playlist_exclusions.json",
     "data-files-brave-psst": "node scripts/dataFilesBravePsst.js",
+    "data-files-web-mcp": "node scripts/dataFilesWebMcp.js",
     "generate-ad-block-manifests": "node scripts/generateManifestForRustAdblock.js",
     "generate-ntp-background-images": "node scripts/generateNTPBackgroundImages.js",
     "generate-ntp-sponsored-images": "node scripts/ntp-sponsored-images/generate",
@@ -60,6 +61,7 @@
     "package-query-filter": "node ./scripts/packageQueryFilterComponent.js",
     "package-playlist-exclusions": "node ./scripts/packagePlaylistExclusionsComponent.js",
     "package-brave-psst": "node ./scripts/packageBravePsstComponent.js",
+    "package-web-mcp": "node ./scripts/packageWebMcpComponent.js",
     "generate-puffpatches": "node ./scripts/generatePuffpatches",
     "upload-component": "node ./scripts/uploadComponent"
   },

--- a/scripts/dataFilesWebMcp.js
+++ b/scripts/dataFilesWebMcp.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Checks out the latest revision of the brave-webmcp repository (main branch)
+// and assembles the component resource directory that packageWebMcpComponent.js
+// stages into the CRX. The scripts are plain JS with no build step, so this
+// only clones and copies the shipped files.
+//
+// Example usage:
+//  npm run data-files-web-mcp
+
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import fs from 'fs-extra'
+import path from 'path'
+
+const sourcePrefix = './brave-webmcp'
+const sourceRepo = 'git@github.com:brave/brave-webmcp.git'
+const resourceDir = './web-mcp'
+
+if (existsSync(sourcePrefix)) {
+  // Repo already cloned — fetch and reset to latest main
+  execSync(`git -C ${sourcePrefix} fetch origin main`, { stdio: 'inherit' })
+  execSync(`git -C ${sourcePrefix} reset --hard origin/main`, { stdio: 'inherit' })
+} else {
+  // Fresh clone
+  execSync(`git clone --branch main --depth 1 ${sourceRepo} ${sourcePrefix}`, { stdio: 'inherit' })
+}
+
+// Assemble a clean resource directory containing only what the component ships.
+// The source repo also holds README.md / LICENSE / manifest.json / key.pem,
+// none of which belong in the CRX — the manifest is generated from the template
+// in manifests/web-mcp/ and the key is provisioned separately at signing time.
+fs.removeSync(resourceDir)
+fs.copySync(path.join(sourcePrefix, 'scripts'), path.join(resourceDir, 'scripts'))

--- a/scripts/packageWebMcpComponent.js
+++ b/scripts/packageWebMcpComponent.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Example usage:
+//  npm run package-web-mcp -- --binary "/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary" --key-file path/to/web-mcp.pem
+
+import commander from 'commander'
+import fs from 'fs-extra'
+import { mkdirp } from 'mkdirp'
+import path from 'path'
+import util from '../lib/util.js'
+import ntpUtil from '../lib/ntpUtil.js'
+
+// Resource directory assembled by scripts/dataFilesWebMcp.js (contains scripts/).
+const webMcpResourceDir = path.join(path.resolve(), 'web-mcp')
+
+const getOriginalManifest = () => {
+  return path.join(path.resolve(), 'manifests', 'web-mcp', 'default-manifest.json')
+}
+
+const stageFiles = util.stageDir.bind(
+  undefined,
+  webMcpResourceDir,
+  getOriginalManifest())
+
+const generateCRXFile = (binary, endpoint, region, componentID, privateKeyFile,
+  publisherProofKey, publisherProofKeyAlt) => {
+  const stagingDir = path.join('build', 'web-mcp')
+  const crxFile = path.join(stagingDir, 'web-mcp.crx')
+  mkdirp.sync(stagingDir)
+  util.getNextVersion(endpoint, region, componentID).then((version) => {
+    stageFiles(version, stagingDir)
+    util.generateCRXFile(binary, crxFile, privateKeyFile, publisherProofKey,
+      publisherProofKeyAlt, stagingDir)
+    console.log(`Generated ${crxFile} with version number ${version}`)
+  })
+}
+
+util.installErrorHandlers()
+
+util.addCommonScriptOptions(
+  commander
+    .option('-k, --key-file <file>', 'file containing private key for signing crx file'))
+  .parse(process.argv)
+
+let privateKeyFile = ''
+if (commander.keyFile && fs.existsSync(commander.keyFile)) {
+  privateKeyFile = commander.keyFile
+} else {
+  throw new Error('Missing or invalid private key')
+}
+
+util.createTableIfNotExists(commander.endpoint, commander.region).then(() => {
+  const [, componentID] = ntpUtil.generatePublicKeyAndID(privateKeyFile)
+  generateCRXFile(commander.binary, commander.endpoint, commander.region,
+    componentID, privateKeyFile, commander.publisherProofKey, commander.publisherProofKeyAlt)
+})


### PR DESCRIPTION
Series https://github.com/brave/brave-browser/issues/55232

Adds new WebMCP Tool Scripts CRX Component packaging.

Component ID: `eingdhelnaolbpcdkgddekhifcjfkalf`

This will need a new Jenkins job as well.

PEM is uploaded to 1Password Extensions Developer vault in `Brave WebMCP Component Key`.

The scripts are sourced from the https://github.com/brave/brave-webmcp repo, and
the component manifest is owned here in `manifests/web-mcp/default-manifest.json`.

1. To prepare data for packaging (clones brave-webmcp and stages
   the `scripts/` directory):
`npm run data-files-web-mcp`

2. Then packaging:
`npm run package-web-mcp`